### PR TITLE
feat(community): Add Skill Request Discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/skill_request.yml
+++ b/.github/DISCUSSION_TEMPLATE/skill_request.yml
@@ -1,0 +1,39 @@
+name: Skill Request
+description: Request a new Claude Code Skill from a domain expert
+title: "[Skill Request]: "
+labels: ["skill request"]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for requesting a new skill! Our community of PhDs and domain experts can help build it if you provide the right context."
+  - type: input
+    id: domain
+    attributes:
+      label: Target Domain / Subdomain
+      description: e.g., Physics / Condensed Matter
+      placeholder: Biology
+    validations:
+      required: true
+  - type: input
+    id: skill_name
+    attributes:
+      label: Proposed Skill Name
+      description: What should this skill be called?
+      placeholder: alphafold-prediction
+    validations:
+      required: true
+  - type: textarea
+    id: purpose
+    attributes:
+      label: What are you trying to accomplish?
+      description: Describe the reasoning task you need the AI agent to perform.
+      placeholder: "I want an agent that can..."
+    validations:
+      required: true
+  - type: textarea
+    id: resources
+    attributes:
+      label: Relevant Tools or Resources (Optional)
+      description: Links to essential textbooks, papers, or databases the expert should include.
+    validations:
+      required: false

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ Each skill is written by a domain expert and encodes the knowledge, tools, reaso
 
 ### 1.3 What can you do
 
-Contribute your expertise, or use this repo to supercharge your AI agent's scientific discovery.
+- **As an Expert:** Contribute your expertise to supercharge AI agents' scientific discovery.
+- **As an AI User:** Use this repo to supercharge your agent, and **[Request a New Skill in Discussions](https://github.com/HHHHHejia/OpenScientist/discussions/categories/skill-requests)** if there's a domain you need an expert to codify!
 
 ### 1.4 Why should you contribute?
 
@@ -133,6 +134,9 @@ We welcome contributions from domain experts. See [CONTRIBUTING.md](utils/CONTRI
 A domain maintainer listed in [CODEOWNERS](.github/CODEOWNERS) will be automatically assigned to review your PR for scientific accuracy.
 
 **Don't see your field?** You can propose a new subdomain or top-level domain — see [CONTRIBUTING.md § Propose a New Area](utils/CONTRIBUTING.md#3-propose-a-new-area).
+
+### 3.3 Request a Skill
+Not a domain expert but need an AI skill? Open a **[Skill Request](https://github.com/HHHHHejia/OpenScientist/discussions/categories/skill-requests)** in GitHub Discussions. A domain expert from the community might pick it up and write the reasoning protocol for you!
 
 ---
 


### PR DESCRIPTION
Adds a GitHub Discussion template so users can request specific AI reasoning skills from the expert community. Updated the README to surface this feature. Note: Maintainers please make sure to enable Discussions in the repository settings and create a category called 'Skill Requests'!