### PR TITLE
feat: make Chinese Name optional in reviewer application

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintainer-application.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-application.yml
@@ -22,10 +22,10 @@ body:
     id: chinese_name
     attributes:
       label: Chinese Name
-      description: Your full name in Chinese
+      description: Your full name in Chinese (optional, leave blank if not applicable)
       placeholder: "e.g. 阿尔伯特·爱因斯坦"
     validations:
-      required: true
+      required: false
 
   - type: input
     id: github_username

--- a/.github/workflows/onboard-maintainer.yml
+++ b/.github/workflows/onboard-maintainer.yml
@@ -51,7 +51,8 @@ jobs:
             }
 
             const englishName = extractField('English Name');
-            const chineseName = extractField('Chinese Name');
+            const chineseNameRaw = extractField('Chinese Name');
+            const chineseName = (chineseNameRaw && chineseNameRaw !== '_No response_') ? chineseNameRaw : englishName;
             const githubUsername = extractField('GitHub Username');
             const affiliation = extractField('Affiliation');
             const shortAffiliation = extractField('Short Affiliation');


### PR DESCRIPTION
## Summary
- Make the Chinese Name field optional in the reviewer application issue template
- Workflow falls back to English Name when Chinese Name is blank or not provided
- Enables non-Chinese reviewers to apply without entering a Chinese name

## Test plan
- [ ] Submit a reviewer application with Chinese Name left blank — workflow should use English Name as fallback
- [ ] Submit a reviewer application with Chinese Name filled in — workflow should use the provided Chinese Name
- [ ] Verify `docs/index.html` and `docs/reviewers.html` render correctly with English-only names

🤖 Generated with [Claude Code](https://claude.com/claude-code)