### PR TITLE
[codex] document extract-knowhow redesign need

### DIFF
--- a/extract-knowhow/README.md
+++ b/extract-knowhow/README.md
@@ -51,6 +51,19 @@ The command will:
 5. **Present** a report for your review and confirmation
 6. **Generate** OpenScientist-format skill files ready for contribution
 
+## Current Limitation
+
+`extract-knowhow` is installed for both Claude Code and Codex CLI, but the workflow is still effectively **Claude-first** in how it is framed and validated. It does not yet have a first-class cross-agent review step, and it does not yet treat peer review between Claude Code, Codex CLI, and Gemini as part of the extraction contract.
+
+That means the current package is useful, but it likely needs a broader redesign if OpenScientist wants extraction to be genuinely multi-agent rather than "generated once by a single assistant and then trusted."
+
+The likely redesign direction is:
+
+- make agent-to-agent review an explicit step rather than an optional manual habit
+- define a single-review handoff contract across Claude Code, Codex CLI, and Gemini
+- make the generated report preserve reviewer identity, review outcome, and review notes
+- distinguish "agent-generated draft knowledge" from "peer-reviewed reusable skill"
+
 ## Output
 
 Generated skill files follow the [OpenScientist skill format](https://github.com/OpenScientists/OpenScientist/blob/main/utils/SKILL_SCHEMA.md) with all required sections:

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,8 @@ $extract-knowhow
 
 The command automatically scans your conversation history, extracts research know-how, and opens an interactive report in your browser — where you can review, edit, and submit skills directly to OpenScientist via GitHub.
 
+Note: the current `extract-knowhow` workflow is still stronger in Claude Code than in a true multi-agent setup. If OpenScientist wants extracted skills to be reviewed across Claude Code, Codex CLI, and Gemini, the package likely needs a redesign rather than just incremental prompt edits.
+
 ### Method B: One-Click Prompt for Web Users (ChatGPT / Claude / Gemini)
 
 Enable memory so the AI can access your history:


### PR DESCRIPTION
## What changed
- document that `extract-knowhow` is still effectively Claude-first even though it is installed for both Claude Code and Codex CLI
- state that a broader redesign is likely needed if OpenScientist wants true multi-agent extraction and review
- outline the redesign direction: explicit peer review handoff, single-review contract, report-level review metadata, and a clear distinction between draft and reviewed skills

## Why
The current package can install into multiple environments, but the workflow still behaves like a single-agent generation flow. That makes it too easy to treat extracted skills as reusable artifacts before defining how cross-agent review should work.

## Impact
This PR does not change behavior. It makes the design gap explicit in the docs so future feature work has a clear target.
