### PR TITLE
[codex] add AI skill usage disclaimer

### DIFF
--- a/extract-knowhow/README.md
+++ b/extract-knowhow/README.md
@@ -8,6 +8,8 @@ When you use Claude Code for scientific research — data analysis, paper writin
 
 `/extract-knowhow` analyzes your conversation history and extracts this knowledge into structured, reusable skill files that follow the OpenScientist format.
 
+Generated skills should be treated as high-value but potentially resource-intensive guidance: applying one may trigger large edits, long tool runs, or significant token usage depending on the task.
+
 ## Install
 
 ```bash

--- a/extract-knowhow/templates/report.html
+++ b/extract-knowhow/templates/report.html
@@ -239,6 +239,10 @@ reviewed_by: []
 
 ${desc}
 
+## AI Usage Disclaimer
+
+This skill may trigger substantial file modifications, long-running tool usage, and significant token consumption. Treat it as expert guidance rather than a guarantee of correctness, and review the proposed scope, cost, and downstream effects before letting an AI agent execute it at full depth.
+
 ## Tools
 
 ${tools.length ? tools.map(t=>'- **'+t.split(' — ')[0]+'**'+(t.includes(' — ')?': '+t.split(' — ').slice(1).join(' — '):'')).join('\n') : '- N/A'}

--- a/extract-knowhow/templates/skill-template.md
+++ b/extract-knowhow/templates/skill-template.md
@@ -31,6 +31,13 @@ reviewed_by: []
      Example: "Use this skill when analyzing experimental data involving quantum entanglement.
      It guides the AI through Bell inequality calculations and statistical interpretation." -->
 
+## AI Usage Disclaimer
+<!-- REQUIRED -->
+<!-- Explain that applying this skill can trigger broad edits, long-running tool calls, or high token usage.
+     Make clear that the skill is guidance, not a guarantee, and that users should review scope/cost before running it. -->
+
+This skill may trigger substantial file modifications, long-running tool usage, and significant token consumption. Treat it as expert guidance rather than a guarantee of correctness, and review the proposed scope, cost, and downstream effects before letting an AI agent execute it at full depth.
+
 ## Tools
 <!-- REQUIRED -->
 <!-- List the key tools, software, libraries, databases, or instruments used in this domain.

--- a/extract-knowhow/tests/test-postinstall.js
+++ b/extract-knowhow/tests/test-postinstall.js
@@ -9,6 +9,8 @@ const { execFileSync } = require("child_process");
 const COMMANDS_DIR = path.join(os.homedir(), ".claude", "commands");
 const TARGET = path.join(COMMANDS_DIR, "extract-knowhow.md");
 const SCRIPT_DIR = path.join(__dirname, "..", "scripts");
+const TEMPLATE = path.join(__dirname, "..", "templates", "report.html");
+const SKILL_TEMPLATE = path.join(__dirname, "..", "templates", "skill-template.md");
 
 let passed = 0;
 let failed = 0;
@@ -35,6 +37,13 @@ assert(fs.existsSync(TARGET), "Command file exists after install");
 const content = fs.readFileSync(TARGET, "utf-8");
 assert(content.includes("extract-knowhow"), "Command file contains expected content");
 assert(content.startsWith("#"), "Command file starts with markdown header");
+
+console.log("\nTest: disclaimer templates");
+const template = fs.readFileSync(TEMPLATE, "utf-8");
+const skillTemplate = fs.readFileSync(SKILL_TEMPLATE, "utf-8");
+assert(template.includes("## AI Usage Disclaimer"), "Generated report skill markdown includes AI usage disclaimer");
+assert(skillTemplate.includes("## AI Usage Disclaimer"), "Manual skill template includes AI usage disclaimer");
+assert(skillTemplate.includes("significant token consumption"), "Manual skill template warns about token cost");
 
 console.log("\nTest: postuninstall.js");
 execFileSync(process.execPath, [path.join(SCRIPT_DIR, "postuninstall.js")], { stdio: "pipe" });

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,8 @@ This intuition lives in your head — the know-how, the heuristics, the reasonin
 
 Each skill encodes the knowledge, tools, reasoning protocols, and common pitfalls of a scientific field. Skills can be written by domain experts or **auto-extracted from your research conversations** using `/extract-knowhow`. Point your AI agent at a skill, and it reasons like a domain expert.
 
+Using a skill is not free: a strong skill can cause an AI agent to make broad modifications, run long workflows, or consume significant tokens. Treat skills as expert guidance and review the expected scope and cost before executing them deeply.
+
 ---
 
 <h2 align="center">2. How to Contribute</h2>


### PR DESCRIPTION
## What changed
- add an explicit `AI Usage Disclaimer` section to the manual skill template
- inject the same disclaimer into skill drafts generated from the extract-knowhow HTML report
- document in the READMEs that skills can trigger broad modifications, long workflows, and significant token usage
- add regression coverage so the disclaimer stays present in both the manual and generated templates

## Why
Skills encode valuable domain knowledge, but applying them through an AI agent can be expensive and high-impact. The repository should say that clearly wherever skills are created or consumed.

## Impact
Contributors and users now see the cost/scope warning in the skill artifact itself instead of having to infer it from context.

## Validation
- `npm test`
