### PR TITLE
[codex] fix skill submission role prefill and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-submit-skill.yml
+++ b/.github/ISSUE_TEMPLATE/01-submit-skill.yml
@@ -10,7 +10,7 @@ body:
 
         **How to generate a skill:**
         1. Install: `npm install -g @openscientist/extract-knowhow`
-        2. In Claude Code: `/model opus[1m]` → `/effort max` → `/extract-knowhow`
+        2. Recommended in Claude Code for highest-quality extraction: `/model opus[1m]` → `/effort max` → `/extract-knowhow`
         3. Review the generated file, then paste its content here.
 
   - type: input
@@ -22,24 +22,12 @@ body:
     validations:
       required: true
 
-  - type: dropdown
+  - type: input
     id: role
     attributes:
       label: Role
-      description: Your current academic or professional role
-      options:
-        - "Undergraduate Student"
-        - "Master's Student"
-        - "PhD Candidate"
-        - "Postdoctoral Researcher"
-        - "Research Scientist"
-        - "Research Engineer"
-        - "Assistant Professor"
-        - "Associate Professor"
-        - "Professor"
-        - "Principal Investigator (PI)"
-        - "Industry Researcher"
-        - "Independent Researcher"
+      description: Your current academic or professional role. Free text is used here so the report page can prefill it correctly.
+      placeholder: "e.g. PhD Candidate"
     validations:
       required: true
 

--- a/extract-knowhow/templates/report.html
+++ b/extract-knowhow/templates/report.html
@@ -81,23 +81,23 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
     <div class="author-field">Institution: <input id="author-inst" type="text" placeholder="e.g. ETH Zürich Physics"></div>
     <div class="author-field">Role: <select id="author-role" style="background:#161b22;border:1px solid #30363d;color:#e6edf3;padding:6px 12px;border-radius:4px;font-size:.9rem">
       <option value="">Select...</option>
-      <option value="Undergraduate">Undergraduate Student</option>
+      <option value="Undergraduate Student">Undergraduate Student</option>
       <option value="Master's Student">Master's Student</option>
       <option value="PhD Candidate">PhD Candidate</option>
-      <option value="Postdoc">Postdoctoral Researcher</option>
+      <option value="Postdoctoral Researcher">Postdoctoral Researcher</option>
       <option value="Research Scientist">Research Scientist</option>
       <option value="Research Engineer">Research Engineer</option>
       <option value="Assistant Professor">Assistant Professor</option>
       <option value="Associate Professor">Associate Professor</option>
       <option value="Professor">Professor</option>
-      <option value="Principal Investigator">Principal Investigator (PI)</option>
+      <option value="Principal Investigator (PI)">Principal Investigator (PI)</option>
       <option value="Industry Researcher">Industry Researcher</option>
       <option value="Independent Researcher">Independent Researcher</option>
     </select></div>
   </div>
   <div id="projects"></div>
   <div class="submit-section">
-    <div class="submit-info">Review and edit your skills above. Click "Submit to GitHub" on each skill, or submit all accepted skills at once.</div>
+    <div class="submit-info">Review and edit your skills above. Click "Submit to GitHub" on each skill, or submit all accepted skills at once. Your selected role will be prefilled in the GitHub issue form.</div>
     <button class="submit-btn" onclick="submitAll()">Submit All Accepted to GitHub</button>
     <div class="output" id="output">
       <p style="color:#3fb950;margin-bottom:.5rem" id="submit-msg"></p>

--- a/extract-knowhow/tests/test-postinstall.js
+++ b/extract-knowhow/tests/test-postinstall.js
@@ -9,6 +9,8 @@ const { execFileSync } = require("child_process");
 const COMMANDS_DIR = path.join(os.homedir(), ".claude", "commands");
 const TARGET = path.join(COMMANDS_DIR, "extract-knowhow.md");
 const SCRIPT_DIR = path.join(__dirname, "..", "scripts");
+const REPORT_TEMPLATE = path.join(__dirname, "..", "templates", "report.html");
+const ISSUE_TEMPLATE = path.join(__dirname, "..", "..", ".github", "ISSUE_TEMPLATE", "01-submit-skill.yml");
 
 let passed = 0;
 let failed = 0;
@@ -35,6 +37,14 @@ assert(fs.existsSync(TARGET), "Command file exists after install");
 const content = fs.readFileSync(TARGET, "utf-8");
 assert(content.includes("extract-knowhow"), "Command file contains expected content");
 assert(content.startsWith("#"), "Command file starts with markdown header");
+
+console.log("\nTest: submission form alignment");
+const reportTemplate = fs.readFileSync(REPORT_TEMPLATE, "utf-8");
+const issueTemplate = fs.readFileSync(ISSUE_TEMPLATE, "utf-8");
+assert(reportTemplate.includes('value="PhD Candidate"'), "Report template keeps full role labels for issue prefill");
+assert(reportTemplate.includes('value="Principal Investigator (PI)"'), "Report template keeps full PI label for issue prefill");
+assert(issueTemplate.includes("- type: input\n    id: role"), "Issue template uses text input for role prefill compatibility");
+assert(issueTemplate.includes("Recommended in Claude Code for highest-quality extraction"), "Issue template documents the recommended Claude model setup");
 
 console.log("\nTest: postuninstall.js");
 execFileSync(process.execPath, [path.join(SCRIPT_DIR, "postuninstall.js")], { stdio: "pipe" });

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ npm install -g @openscientist/extract-knowhow
 
 **Claude Code:**
 ```
+/model opus[1m]
+/effort max
 /extract-knowhow
 ```
 
@@ -60,7 +62,7 @@ npm install -g @openscientist/extract-knowhow
 $extract-knowhow
 ```
 
-The command automatically scans your conversation history, extracts research know-how, and opens an interactive report in your browser — where you can review, edit, and submit skills directly to OpenScientist via GitHub.
+The recommended Claude Code setup for highest-quality extraction is `/model opus[1m]` with `/effort max`. The command then scans your conversation history, extracts research know-how, and opens an interactive report in your browser — where you can review, edit, and submit skills directly to OpenScientist via GitHub.
 
 ### Method B: One-Click Prompt for Web Users (ChatGPT / Claude / Gemini)
 

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -52,6 +52,8 @@ npm install -g @openscientist/extract-knowhow
 
 **Claude Code:**
 ```
+/model opus[1m]
+/effort max
 /extract-knowhow
 ```
 
@@ -60,7 +62,7 @@ npm install -g @openscientist/extract-knowhow
 $extract-knowhow
 ```
 
-该命令会自动扫描你的对话历史，提取科研 know-how，并在浏览器中打开交互式报告 — 你可以在其中审核、编辑，并直接通过 GitHub 提交到 OpenScientist。
+为获得更高质量的提取结果，推荐在 Claude Code 中先设置 `/model opus[1m]` 和 `/effort max`。随后该命令会自动扫描你的对话历史，提取科研 know-how，并在浏览器中打开交互式报告 — 你可以在其中审核、编辑，并直接通过 GitHub 提交到 OpenScientist。
 
 ### 方式 B：网页版用户一键提取（ChatGPT / Claude / Gemini）
 


### PR DESCRIPTION
## What changed
- fix skill submission role prefilling by changing the GitHub issue form `role` field from a dropdown to a text input that supports URL prefill
- align the local report role option values with the full labels used in skill submissions
- update the report copy to state that the selected role will be prefilled in the GitHub issue form
- align the top-level English and Chinese READMEs with the issue template by documenting `/model opus[1m]` and `/effort max` as the recommended Claude Code setup for highest-quality extraction
- add regression coverage for the report/issue-form alignment

## Why
The generated local report already passes `role` in the issue URL, but GitHub issue forms only reliably prefill custom text fields, not dropdowns. This caused the issue form to fall back to its default value instead of preserving the role chosen in the report.

## Impact
Submitting a generated skill from the report now carries the selected role through correctly, and the docs no longer disagree about the recommended Claude Code setup.

## Validation
- `npm test`
