### PR TITLE
fix: use bracket-balanced JSON extraction in classify-projects.js

### DIFF
--- a/extract-knowhow/scripts/classify-projects.js
+++ b/extract-knowhow/scripts/classify-projects.js
@@ -183,12 +183,22 @@ async function main() {
       };
     }
 
-    // Parse JSON from Sonnet output
+    // Parse JSON from Sonnet output.
+    // Use bracket-balanced extraction instead of a greedy regex — if any text
+    // follows the JSON (e.g. a Claude Code hook prints to stdout after the
+    // response), the greedy /\{[\s\S]*\}/ would stretch to the last "}" in
+    // that trailing text and produce invalid JSON for JSON.parse.
     let classification;
     try {
-      const jsonMatch = output.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) throw new Error('No JSON found in output');
-      classification = JSON.parse(jsonMatch[0]);
+      const start = output.indexOf('{');
+      if (start === -1) throw new Error('No JSON found in output');
+      let depth = 0, end = -1;
+      for (let i = start; i < output.length; i++) {
+        if (output[i] === '{') depth++;
+        else if (output[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+      }
+      if (end === -1) throw new Error('Unbalanced JSON object in output');
+      classification = JSON.parse(output.slice(start, end + 1));
     } catch (e) {
       if (opts.verbose) console.log(`  ${slug}: PARSE ERROR — ${e.message}\n    Output: ${output.substring(0, 200)}`);
       return {


### PR DESCRIPTION
## Problem

`classify-projects.js` parses the AI response with a greedy regex:

```js
const jsonMatch = output.match(/\{[\s\S]*\}/);
classification = JSON.parse(jsonMatch[0]);
```

When any text is appended to stdout **after** the JSON — such as a Claude Code `SessionEnd` hook that fails and prints its error to stdout — the greedy `[\s\S]*` stretches to the **last** `}` in that trailing text. `JSON.parse` then receives the JSON plus the hook error, and throws:

```
Unexpected non-whitespace character after JSON at position N
```

This silently marks every affected project as `type: "error"` with all sessions skipped, so they never reach skill extraction. In practice this caused **33 out of 41 projects** to be dropped on a machine with a misconfigured `SessionEnd` hook.

## Root cause

`platform.js` correctly discards stderr (`proc.stderr` is not pushed into `chunks`). But stdout itself can still carry trailing content if the `claude -p` process or any hook writes extra text after the JSON response.

## Fix

Replace the greedy regex with a bracket-depth counter that stops at the first balanced closing brace:

```js
const start = output.indexOf('{');
let depth = 0, end = -1;
for (let i = start; i < output.length; i++) {
  if (output[i] === '{') depth++;
  else if (output[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
}
classification = JSON.parse(output.slice(start, end + 1));
```

This safely ignores any trailing output after the JSON object, making the parser robust to hook noise or any other stdout pollution.

## Test

```js
const output = `{"type":"engineering","domain":"computer-science","subdomain":"software-engineering","reason":"test","skip_patterns":[]}
SessionEnd hook [node "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/session-end.js"] failed: Error: Cannot find module`;

// Before: JSON.parse throws "Unexpected non-whitespace character after JSON"
// After:  parses correctly → { type: 'engineering', ... }
```