### PR TITLE
docs: replace knowledge tree header with researchskills.ai link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,13 +17,7 @@ Today: We're launching the largest academic collaboration in human history
 **— 🏛️ Building the Library of Alexandria for AGI, Accelerating Automated Scientific Discovery.**
 
 <p align="center">
-  <a href="https://openscientists.github.io/OpenScientist/">
-    <img src="https://raw.githubusercontent.com/OpenScientists/OpenScientist/main/utils/assets/knowledge-tree-v2.png" alt="Knowledge Tree" width="100%">
-  </a>
-</p>
-
-<p align="center">
-  <a href="https://openscientists.github.io/OpenScientist/">View Interactive Knowledge Tree →</a>
+  <a href="https://researchskills.ai/">https://researchskills.ai/</a>
 </p>
 
 ---

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -17,13 +17,7 @@
 **— 🏛️ 为 AGI 建一座亚历山大图书馆，加速自动化科学发现。**
 
 <p align="center">
-  <a href="https://openscientists.github.io/OpenScientist/">
-    <img src="https://raw.githubusercontent.com/OpenScientists/OpenScientist/main/utils/assets/knowledge-tree-v2.png" alt="Knowledge Tree" width="100%">
-  </a>
-</p>
-
-<p align="center">
-  <a href="https://openscientists.github.io/OpenScientist/">查看交互式知识树 →</a>
+  <a href="https://researchskills.ai/">https://researchskills.ai/</a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Remove the interactive Knowledge Tree image/link block at the top of both READMEs
- Replace with a direct link to https://researchskills.ai/

## Test plan
- [ ] Render readme.md and readme_zh.md on GitHub and confirm header now shows the researchskills.ai link

🤖 Generated with [Claude Code](https://claude.com/claude-code)