### PR TITLE
fix(extract-knowhow): prevent classify timeouts with concurrency limit

### DIFF
--- a/extract-knowhow/scripts/classify-projects.js
+++ b/extract-knowhow/scripts/classify-projects.js
@@ -35,6 +35,9 @@ const { parsePlatformFlag, createRunner } = require('./platform');
 
 const OUTPUT_PATH = path.join(os.homedir(), '.openscientist', 'cache', 'classification.json');
 
+// Max concurrent AI classify calls — prevents resource thrashing & API rate limits
+const CONCURRENCY = 5;
+
 // ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
@@ -163,9 +166,9 @@ async function main() {
   const result = { projects: {} };
   const projectPaths = Object.keys(byProject);
 
-  console.log(`\nClassifying ${projectPaths.length} projects in parallel...\n`);
+  console.log(`\nClassifying ${projectPaths.length} projects (${CONCURRENCY} at a time)...\n`);
 
-  // Classify all projects via Sonnet in parallel
+  // Classify projects with bounded concurrency
   const classifyOne = async (projPath) => {
     const projSessions = byProject[projPath];
     const slug = projPath.split('/').filter(Boolean).pop() || 'unknown';
@@ -236,7 +239,16 @@ async function main() {
     };
   };
 
-  const classifications = await Promise.all(projectPaths.map(classifyOne));
+  // Process in batches of CONCURRENCY to avoid spawning too many CLI processes
+  const classifications = [];
+  for (let i = 0; i < projectPaths.length; i += CONCURRENCY) {
+    const batch = projectPaths.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(classifyOne));
+    classifications.push(...batchResults);
+    if (i + CONCURRENCY < projectPaths.length) {
+      console.log(`  ... classified ${Math.min(i + CONCURRENCY, projectPaths.length)}/${projectPaths.length} projects`);
+    }
+  }
 
   // Collect results and print
   for (const c of classifications) {

--- a/extract-knowhow/scripts/platform.js
+++ b/extract-knowhow/scripts/platform.js
@@ -93,7 +93,7 @@ function createCCRunner() {
         prompt, verbose, timeoutMs
       );
     },
-    classify(prompt, timeoutMs = 120_000) {
+    classify(prompt, timeoutMs = 300_000) {
       return spawnCC(
         ['-p', '--model', 'sonnet', '--no-session-persistence'],
         prompt, false, timeoutMs
@@ -177,7 +177,7 @@ function createCodexRunner() {
     score(prompt, verbose = false, timeoutMs = 900_000) {
       return spawnCodex(codexBaseArgs('high'), prompt, verbose, timeoutMs);
     },
-    classify(prompt, timeoutMs = 120_000) {
+    classify(prompt, timeoutMs = 300_000) {
       return spawnCodex(codexBaseArgs('medium'), prompt, false, timeoutMs);
     },
   };


### PR DESCRIPTION
## Summary
- Add `CONCURRENCY=5` batch limit to `classify-projects.js` — processes 5 projects at a time instead of all at once via unbounded `Promise.all`
- Increase `classify()` timeout from 120s → 300s in `platform.js` (both CC and Codex runners)

## Problem
When a user has 40+ projects, `classify-projects.js` spawns one `claude`/`codex` CLI process per project **simultaneously**. This causes:
- Resource thrashing (CPU/memory from 40+ concurrent subprocesses)
- API rate limiting on the AI backend
- **30/43 projects timing out** at the 120s limit, reported as `Classification failed: timeout`

## Test plan
- [ ] Run `/extract-knowhow` on a session history with 40+ projects
- [ ] Verify all projects classify successfully (no timeout errors)
- [ ] Verify progress logging shows batch counts (`... classified 5/43 projects`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)