### PR TITLE
revert: remove test skills that bypassed admin review

### DIFF
--- a/skills/computer-science/artificial-intelligence/ktwugoat/procedural/constraint-failure--test.md
+++ b/skills/computer-science/artificial-intelligence/ktwugoat/procedural/constraint-failure--test.md
@@ -1,9 +1,0 @@
----
-name: test
-memory_type: procedural
-subtype: constraint-failure
-domain: computer-science
-subdomain: artificial-intelligence
-contributor: ktwugoat
----
-test

--- a/skills/economics/econometrics/ktwugoat/procedural/operator-fail--test.md
+++ b/skills/economics/econometrics/ktwugoat/procedural/operator-fail--test.md
@@ -1,9 +1,0 @@
----
-name: test
-memory_type: procedural
-subtype: operator-fail
-domain: economics
-subdomain: econometrics
-contributor: ktwugoat
----
-test

--- a/skills/economics/general-economics/ktwugoat/procedural/no-change--test.md
+++ b/skills/economics/general-economics/ktwugoat/procedural/no-change--test.md
@@ -1,9 +1,0 @@
----
-name: test
-memory_type: procedural
-subtype: no-change
-domain: economics
-subdomain: general-economics
-contributor: ktwugoat
----
-xxx

--- a/skills/eess/image-and-video-processing/ktwugoat/procedural/no-change--xx.md
+++ b/skills/eess/image-and-video-processing/ktwugoat/procedural/no-change--xx.md
@@ -1,9 +1,0 @@
----
-name: xx
-memory_type: procedural
-subtype: no-change
-domain: eess
-subdomain: image-and-video-processing
-contributor: ktwugoat
----
-xx


### PR DESCRIPTION
## Summary

- Removes 4 test/junk skill files committed by ktwugoat that bypassed admin review due to a bug in `POST /api/skills/:id/submit` (it called `syncSkillToRepo()` at submit time instead of waiting for admin approval)
- The bug is fixed in OpenScientists/researchskills-server#47
- The 6 legitimate skills under `skills/physics/geophysics/ktwugoat/` (batch submission `fd972ad`) are **not** affected

## Removed files

- `skills/computer-science/.../constraint-failure--test.md`
- `skills/economics/econometrics/.../operator-fail--test.md`
- `skills/economics/general-economics/.../no-change--test.md`
- `skills/eess/.../no-change--xx.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)