### PR TITLE
add project consent gate to extract-knowhow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# OpenScientist — CLAUDE.md
+
+## Editing Rules
+
+- When adding new logic (e.g., a new pipeline step), do NOT reword existing text. Keep upstream wording exactly as-is and only insert the new content. Minimal diff principle: the smallest change that achieves the goal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 ## Editing Rules
 
 - When adding new logic (e.g., a new pipeline step), do NOT reword existing text. Keep upstream wording exactly as-is and only insert the new content. Minimal diff principle: the smallest change that achieves the goal.
+- When modifying JS, use `codex review` to have the JS calculated or mock-run step by step before committing.

--- a/extract-knowhow/README.md
+++ b/extract-knowhow/README.md
@@ -41,10 +41,11 @@ The command runs a 7-stage pipeline:
 1. **Scan** — discover all Claude Code and Codex sessions
 2. **Classify** — identify research vs. engineering projects (Sonnet)
 3. **Confirm** — you choose which projects to scan (multi-select)
-4. **Extract** — extract research skills per session (Sonnet)
-5. **Clean & Score** — Opus reviews, rejects, merges, and scores skills
-6. **Finalize** — collect results; upload only with your consent
-7. **Summary** — report results with review statistics
+4. **Extract** — extract research skills per session (Sonnet), organized by cognitive memory type
+5. **Clean** — review extracted skills with Opus: reject engineering content, fix PII, merge duplicates
+6. **Score** — assess each skill's value on 3 dimensions with Opus (procedural / semantic / episodic, 0-5)
+7. **Finalize** — upload cleaned, scored skills to [researchskills.ai](https://researchskills.ai)
+8. **Summary** — report results with review statistics
 
 ## Output
 

--- a/extract-knowhow/README.md
+++ b/extract-knowhow/README.md
@@ -100,7 +100,7 @@ npm uninstall -g @openscientist/extract-knowhow
 - All analysis happens locally via your Claude Code / Codex session
 - Session data is read from `~/.claude/projects/` and `~/.codex/` on your machine
 - **You choose which projects to scan** — the tool pauses after classification for your selection
-- No conversation history is read for unselected projects
+- Unselected projects are skipped for extraction (classification reads only brief message samples)
 - AI auto-strips personal information; you review before submitting
 - Nothing is uploaded without your explicit consent
 

--- a/extract-knowhow/README.md
+++ b/extract-knowhow/README.md
@@ -40,10 +40,10 @@ The command runs a 7-stage pipeline:
 
 1. **Scan** — discover all Claude Code and Codex sessions
 2. **Classify** — identify research vs. engineering projects (Sonnet)
-3. **Extract** — extract research skills per session (Sonnet), organized by cognitive memory type
-4. **Clean** — review extracted skills with Opus: reject engineering content, fix PII, merge duplicates
-5. **Score** — assess each skill's value on 3 dimensions with Opus (procedural / semantic / episodic, 0-5)
-6. **Finalize** — upload cleaned, scored skills to [researchskills.ai](https://researchskills.ai)
+3. **Confirm** — you choose which projects to scan (multi-select)
+4. **Extract** — extract research skills per session (Sonnet)
+5. **Clean & Score** — Opus reviews, rejects, merges, and scores skills
+6. **Finalize** — collect results; upload only with your consent
 7. **Summary** — report results with review statistics
 
 ## Output
@@ -99,9 +99,10 @@ npm uninstall -g @openscientist/extract-knowhow
 
 - All analysis happens locally via your Claude Code / Codex session
 - Session data is read from `~/.claude/projects/` and `~/.codex/` on your machine
-- No data is sent to external servers beyond your normal Claude Code API usage
+- **You choose which projects to scan** — the tool pauses after classification for your selection
+- No conversation history is read for unselected projects
 - AI auto-strips personal information; you review before submitting
-- You choose what to submit — nothing is sent without your explicit action
+- Nothing is uploaded without your explicit consent
 
 ## License
 

--- a/extract-knowhow/commands/SKILL.md
+++ b/extract-knowhow/commands/SKILL.md
@@ -6,7 +6,7 @@ description: "Extract research skills from conversation history into OpenScienti
 
 Extract research skills from the user's Codex session history for **OpenScientist**.
 
-**Run fully automatically with ZERO user interaction.** Do not pause or ask questions. Report progress at each milestone.
+**Run automatically with TWO pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
 
 > **Prerequisite:** This skill spawns nested `codex exec` calls that need full network and filesystem access. Start Codex with: `codex -a never -s danger-full-access` (or `--dangerously-bypass-approvals-and-sandbox`). If the parent session is sandboxed, nested calls will fail with network errors.
 
@@ -89,6 +89,31 @@ Report: `"Classified N projects. Proceeding with M."`
 
 ---
 
+## Stage 2.5 — Project Consent Gate
+
+**PAUSE and ask the user.** After classification, show all discovered projects and let the user choose which to scan.
+
+Read `~/.openscientist/cache/classification.json` and display:
+
+```
+Select which projects to scan for research skills:
+
+  [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
+  [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
+  [ ] 3. Personal Website             (3 sessions, engineering)
+  [ ] 4. Dotfiles                     (2 sessions, other)
+
+Enter numbers to toggle, or press Enter to continue:
+```
+
+Research projects are pre-selected; engineering/other are deselected.
+
+Only pass user-approved projects to Stage 3+. Remove deselected project session IDs from all subsequent `--session-ids` arguments.
+
+Report: `"Proceeding with N projects (M sessions) after user confirmation."`
+
+---
+
 ## Stage 3 — Extract Skills Per Session
 
 ### MANDATORY: Use --single-batch and loop. NEVER run all at once.
@@ -159,9 +184,11 @@ Report: `"Scored N skills. Avg: procedural X.X, semantic X.X, episodic X.X."`
 
 ---
 
-## Stage 6 — Finalize Per Project
+## Stage 6 — Finalize Per Project (collect only, no upload yet)
 
 Use the AI-generated `project_name` from classification.json (Stage 2). Do NOT use the raw folder name.
+
+**Do NOT pass `--upload` here.** Collect skills locally first. Upload requires explicit user consent in Stage 7.
 
 ```bash
 node ~/.codex/skills/extract-knowhow/scripts/finalize.js \
@@ -175,11 +202,15 @@ node ~/.codex/skills/extract-knowhow/scripts/finalize.js \
 
 ---
 
-## Stage 7 — Terminal Summary
+## Stage 7 — Consent and Upload
+
+**Second consent gate.** Pause and ask the user before uploading anything.
+
+Show the user what was extracted:
 
 ```
 ═══════════════════════════════════════════════════════
-  /extract-knowhow Complete!
+  /extract-knowhow — Extraction Complete!
 ═══════════════════════════════════════════════════════
 
 Extracted N skills from M sessions across P projects:
@@ -191,7 +222,34 @@ Review:
   • Kept: K / Rejected: R / Merged: G
   • Avg scores: procedural X.X, semantic X.X, episodic X.X
 
+⚠ Nothing has been uploaded yet. Your skills are saved
+  locally. Would you like to submit them to OpenScientist
+  for reviewer review?
+
+  Skills will be stored on researchskills.ai and reviewed
+  by a maintainer before publication (CC-BY 4.0).
+═══════════════════════════════════════════════════════
+```
+
+Ask for explicit consent:
+- "Yes, submit for review" — re-run finalize with `--upload`
+- "No, keep local only" — skip upload, tell user where files are saved
+
+If the user consents, re-run finalize with `--upload`:
+
+```bash
+node ~/.codex/skills/extract-knowhow/scripts/finalize.js \
+  --session-ids <ALL-research-session-ids-csv> \
+  --domain <domain> \
+  --subdomain <subdomain> \
+  --contributor "$(git config user.name)" \
+  --project-name "<project_name from classification>" \
+  --project-slug "<slug>" \
+  --upload
+```
+
+Then show:
+```
 Review your skills:
   → https://researchskills.ai/review/batch/<batchId>
-═══════════════════════════════════════════════════════
 ```

--- a/extract-knowhow/commands/extract-knowhow.md
+++ b/extract-knowhow/commands/extract-knowhow.md
@@ -2,7 +2,7 @@
 
 Extract research skills from the user's Claude Code session history for **OpenScientist**.
 
-**Run fully automatically with ZERO user interaction.** Do not pause or ask questions. Report progress at each milestone.
+**Run automatically with TWO pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
 
 You extract three types of cognitive memory from research conversations:
 - **Procedural** — IF-THEN rules for **scientific research** decisions: methodology choices, data interpretation strategies, research direction pivots. NOT engineering workflows.
@@ -80,6 +80,31 @@ Read the output file. For each project with `type: "research"`, use its `researc
 The script generates an AI-summarized `project_name` for each project (e.g. "Protein Folding Simulation Pipeline") instead of using the raw folder name. Use this `project_name` in Stage 6 finalize. If `project_name` is null, fall back to the `slug`.
 
 Report: `"Classified N projects. Proceeding with M."`
+
+---
+
+## Stage 2.5 — Project Consent Gate
+
+**PAUSE and ask the user.** After classification, show all discovered projects and let the user choose which to scan.
+
+Read `~/.openscientist/cache/classification.json` and display:
+
+```
+Select which projects to scan for research skills:
+
+  [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
+  [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
+  [ ] 3. Personal Website             (3 sessions, engineering)
+  [ ] 4. Dotfiles                     (2 sessions, other)
+
+Enter numbers to toggle, or press Enter to continue:
+```
+
+Research projects are pre-selected; engineering/other are deselected.
+
+Use AskUserQuestion to get the selection. Only pass user-approved projects to Stage 3+. Remove deselected project session IDs from all subsequent `--session-ids` arguments.
+
+Report: `"Proceeding with N projects (M sessions) after user confirmation."`
 
 ---
 
@@ -174,7 +199,7 @@ node ~/.claude/utils/finalize.js \
 
 ## Stage 7 — Consent and Upload
 
-**This is the ONLY stage where you pause and ask the user.** All prior stages run automatically.
+**Second consent gate.** Pause and ask the user before uploading anything.
 
 Show the user what was extracted:
 


### PR DESCRIPTION
## Summary
- Add **Stage 3.5: Project Consent Gate** to `extract-knowhow.md` — after classifying projects, the tool pauses and lets the user multi-select which projects to scan
- Update README privacy section to document the consent-before-scanning flow
- No JS/HTML changes needed — postinstall scripts and report template are unaffected

Closes #49

## Test plan
- [x] `npm test` passes (8/8)
- [ ] Run `/extract-knowhow` in Claude Code and verify the tool pauses after Stage 2 with a project list
- [ ] Confirm deselected projects are skipped in Stage 4+

🤖 Generated with [Claude Code](https://claude.com/claude-code)