### PR TITLE
fix(extract-knowhow): skip session gracefully when source file is missing

### DIFF
--- a/extract-knowhow/scripts/extract-skills.js
+++ b/extract-knowhow/scripts/extract-skills.js
@@ -314,9 +314,22 @@ function prepareSession(session) {
     return { sid, skip: 'trivial prompt' };
   }
 
+  // The file_path recorded in work-list.json may have disappeared between
+  // scan and extract (user cleanup, Claude Code retention, project rename).
+  // Treat that as a per-session error so the batch keeps going instead of
+  // the format-session subprocess throwing out of prepareSession().
+  if (!fs.existsSync(session.file_path)) {
+    return { sid, error: 'session file not found (removed after scan?)' };
+  }
+
   // Format
   const outPath = path.join(os.tmpdir(), `session-${sid}.txt`);
-  const meta = formatSession(session.file_path, outPath);
+  let meta;
+  try {
+    meta = formatSession(session.file_path, outPath);
+  } catch (e) {
+    return { sid, error: `format threw: ${(e.message || String(e)).split('\n')[0]}` };
+  }
   if (!meta) {
     return { sid, error: 'format failed' };
   }


### PR DESCRIPTION
## Summary

`extract-skills.js` currently aborts the entire pipeline with `Fatal:` when a single `session.file_path` recorded in `work-list.json` no longer exists on disk (user cleanup / Claude Code retention / project rename between scan and extract). Other sessions scheduled in the same invocation never run.

This PR makes that case a per-session error so the batch keeps going.

## Repro

1. Run `scan-sessions.js` against a Claude projects directory.
2. Delete (or let Claude Code retention remove) a project folder that contains a session listed in the resulting `work-list.json`.
3. Run `extract-skills.js --session-ids <id-of-deleted-file>,<id-of-good-session> --single-batch`.

Before the fix the process exits with:
```
Fatal: Error: Command failed: node .../format-session.js ...
Error: input file not found: /Users/.../old-project/xxx.jsonl
```
…and the second (good) session is never reached.

## Fix

In `prepareSession()`:
- `fs.existsSync(session.file_path)` guard before formatting. On miss, return `{ sid, error: 'session file not found (removed after scan?)' }` — matches the existing `{sid, error: ...}` contract handled at `main()` L395-397.
- Wrap `formatSession()` in `try/catch` so any other failure inside the `format-session.js` subprocess is also contained as a per-session error rather than fatal.

No behavior change on the happy path; no changes to `prepareSession()`'s return shape; no changes elsewhere.

## Verification

Local run on an affected work-list (session file previously deleted on disk):

```
Phase 1: Pre-filtering and formatting...
  98164426-... → ERROR (session file not found (removed after scan?))
  cd405a91-... → SKIP (584 chars < 2000 min)
  0 sessions ready, 1 skipped, 1 errors
```

Previously this crashed on the first session with `Fatal:` before reaching the second. With the fix, both sessions are evaluated and the run ends cleanly.

## Test plan

- [x] Reproduce `Fatal:` crash with unpatched code and a work-list pointing at a deleted session file
- [x] Apply patch, confirm the deleted-file session is logged as `→ ERROR (...)` and the subsequent session is still processed
- [x] Confirm no regression on normal extraction (existing session with readable file still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)