### PR TITLE
fix(extract-knowhow): include project path in session dedup fingerprint

### DIFF
--- a/extract-knowhow/scripts/scan-sessions.js
+++ b/extract-knowhow/scripts/scan-sessions.js
@@ -355,7 +355,7 @@ function scan() {
       start_timestamp: meta.start_timestamp,
     };
 
-    const fp = `${meta.first_prompt || ''}::${meta.user_message_count || 0}`;
+    const fp = `${projectPath}::${meta.first_prompt || ''}::${meta.user_message_count || 0}`;
     const existing = byFingerprint.get(fp);
     if (existing) {
       skipped.duplicate += 1;


### PR DESCRIPTION
## Trigger

When two different research projects have sessions that open with a similar phrase (e.g. \`help me set up the analysis pipeline\`, \`continue\`, \`ultrathink this\`) and happen to have the same \`user_message_count\`, the scan dedup step silently drops the second one — that project disappears entirely from the work-list. This is easy to hit for short, similarly-scoped sessions.

\`scan-sessions.js:358\`:

\`\`\`js
const fp = \`\${meta.first_prompt || ''}::\${meta.user_message_count || 0}\`;
\`\`\`

The key is project-agnostic, so cross-project collisions look identical to same-project duplicates.

## Fix

Include \`projectPath\` in the fingerprint. Cross-project collisions are preserved; intra-project duplicates (the original dedup intent — same session captured twice under the same project) still collapse.

## Test

Reproduced the collision with a small script over the dedup logic (two sessions, same opener, same count, different \`project_path\`): pre-fix accepts 1 and silently skips the other; post-fix accepts both. A third session in the first project with identical opener and count is still dropped as intended.