### PR TITLE
docs: add AI skill usage disclaimer to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ This intuition lives in your head — the know-how, the heuristics, the reasonin
 
 Each skill encodes the knowledge, tools, reasoning protocols, and common pitfalls of a scientific field. Skills can be written by domain experts or **auto-extracted from your research conversations** using `/extract-knowhow`. The command extracts three types of cognitive memory from your research sessions — **procedural** (IF-THEN rules for research impasses), **semantic** (facts LLMs don't know), and **episodic** (concrete research episodes) — then packages them as reusable skills. Point your AI agent at a skill, and it reasons like a domain expert.
 
+> **Note:** Applying a skill may trigger broad edits, long workflows, and significant token usage — review the expected scope before running one deeply.
+
 ---
 
 <h2 align="center">2. How to Contribute</h2>


### PR DESCRIPTION
## Summary
- Add a one-line disclaimer note after the skills description in readme.md
- Simpler alternative to #26 — keeps it to a single, visible location

## Test plan
- [x] Verify readme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)