### PR TITLE
add(skills): 3 negative-guidance procedural skills

### DIFF
--- a/extract-knowhow/package.json
+++ b/extract-knowhow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openscientist/extract-knowhow",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Extract your research trajectory as a decision tree from conversation history for OpenScientist. Supports both Claude Code and Codex.",
   "keywords": [
     "claude-code",

--- a/skills/computer-science/artificial-intelligence/ktwu01/procedural/tie--ai-agent-discipline-operational-failure-modes-to-guard-against.md
+++ b/skills/computer-science/artificial-intelligence/ktwu01/procedural/tie--ai-agent-discipline-operational-failure-modes-to-guard-against.md
@@ -1,0 +1,54 @@
+---
+name: "AI agent discipline: operational failure modes to guard against"
+memory_type: procedural
+subtype: tie
+domain: computer-science
+subdomain: artificial-intelligence
+contributor: ktwu01
+source:
+  type: session
+  ref: "OpenScientists/OpenScientist#61; practitioner field reports 2024-2026"
+extracted_at: 2026-04-20
+---
+
+## Situation
+An AI agent is executing a multi-step research workflow (literature review, experiment design, paper writing, code implementation) and must maintain operational discipline throughout.
+
+## Procedure
+
+### Verification Honesty
+- Do NOT claim "verified" or "confirmed" without showing the specific check performed and its output.
+- Do NOT say "the results are consistent" without displaying the comparison.
+- When asked to verify, execute the verification step and present evidence — never skip to the conclusion.
+
+### Completeness of Search
+- Do NOT stop after finding the first error, match, or relevant paper. Continue searching until diminishing returns are explicit.
+- When reviewing code or text, make a full pass — do not declare "looks good" after checking only the first few lines.
+- When asked "are there any issues?", assume there are multiple and search exhaustively.
+
+### Convention Persistence
+- Do NOT silently revert to textbook defaults when the user has established non-standard conventions (notation, units, variable names, coordinate systems).
+- When conventions are stated, record them and check each output against them before delivering.
+- If uncertain whether a convention still applies, ask — do not assume the default.
+
+### Goal Maintenance
+- Do NOT drift from the stated objective when encountering intermediate complexity. Re-read the original instruction before each major step.
+- Do NOT expand scope ("while I'm here, I'll also...") without explicit permission.
+- Do NOT confuse making progress with achieving the goal — verify the actual deliverable matches the request.
+
+### Resistance to Pressure
+- Do NOT produce an answer just because the user is insistent, if the answer lacks supporting evidence.
+- Do NOT agree with a premise to avoid conflict. If the evidence contradicts the user's assumption, state it clearly.
+- When forced to think deeply and running out of confidence, say "I don't know" rather than fabricating a plausible-sounding response.
+
+### Cross-Validation
+- When possible, verify critical results using an independent method or tool.
+- Do NOT rely on a single source for important factual claims — triangulate.
+- If a result seems too clean or too convenient, double-check it.
+
+## Retrieval Cues
+- Starting a multi-step research or engineering task.
+- User has previously corrected the agent for sloppy verification.
+- Task requires maintaining non-standard conventions across many steps.
+- Agent is about to claim completion of a complex task.
+- User explicitly asks for thoroughness or exhaustive checking.

--- a/skills/computer-science/machine-learning/ktwu01/procedural/tie--research-integrity-antipatterns-deceptive-practices-to-reject-in-paper-writing.md
+++ b/skills/computer-science/machine-learning/ktwu01/procedural/tie--research-integrity-antipatterns-deceptive-practices-to-reject-in-paper-writing.md
@@ -1,0 +1,48 @@
+---
+name: "Research integrity antipatterns: deceptive practices to reject in paper writing"
+memory_type: procedural
+subtype: tie
+domain: computer-science
+subdomain: machine-learning
+contributor: ktwu01
+source:
+  type: literature
+  ref: "hzwer/WritingAIPaper NotGoodIdeas.md; community field observations 2022-2026"
+extracted_at: 2026-04-20
+---
+
+## Situation
+An AI agent is drafting, reviewing, or evaluating an ML/AI research paper and must decide whether a claimed contribution or evaluation is scientifically honest.
+
+## Procedure
+
+### Computational Honesty
+- Do NOT hide actual training cost behind misleading batch-size or epoch counts.
+- Do NOT report wall-clock time without specifying hardware, parallelism, and whether warmup is included.
+- Do NOT present a large model's distilled output as if the small model learned independently.
+
+### Hyperparameter Transparency
+- Do NOT treat critical hyperparameters as "magic numbers" buried in appendices.
+- Do NOT tune hyperparameters on the test set and report them as if chosen a priori.
+- Do NOT selectively report only the learning-rate schedule that worked.
+
+### Method Integrity
+- Do NOT rebrand an existing technique under a new name without citing the original.
+- Do NOT add minor architectural tweaks (activation swap, extra skip connection) and claim them as the core contribution without ablation.
+- Do NOT use an elaborate loss function whose individual contribution is never isolated.
+
+### Evaluation Honesty
+- Do NOT cherry-pick favorable metrics while omitting standard ones where the method underperforms.
+- Do NOT selectively report datasets; if a benchmark is standard in the field, include it or explain the omission.
+- Do NOT use inconsistent preprocessing or evaluation protocols between your method and baselines.
+- Do NOT compare against outdated or weak baselines when stronger ones exist.
+
+### Reproducibility
+- Do NOT withhold code, data splits, or random seeds that are necessary to reproduce results.
+- Do NOT present results averaged over a suspiciously small number of runs without confidence intervals.
+
+## Retrieval Cues
+- Writing or reviewing a contributions/experiments section.
+- Evaluating whether a claimed improvement is scientifically valid.
+- Checking if an ablation study is complete and fair.
+- Assessing whether baselines are appropriate and up-to-date.

--- a/skills/computer-science/machine-learning/ktwu01/procedural/tie--scientific-prose-style-rules-for-avoiding-llm-writing-antipatterns.md
+++ b/skills/computer-science/machine-learning/ktwu01/procedural/tie--scientific-prose-style-rules-for-avoiding-llm-writing-antipatterns.md
@@ -1,0 +1,49 @@
+---
+name: "Scientific prose style rules for avoiding LLM writing antipatterns"
+memory_type: procedural
+subtype: tie
+domain: computer-science
+subdomain: machine-learning
+contributor: ktwu01
+source:
+  type: literature
+  ref: "yzhao062/agent-style; Strunk & White; Orwell 'Politics and the English Language'; Gopen & Swan 1990"
+extracted_at: 2026-04-20
+---
+
+## Situation
+An AI agent is writing or editing scientific prose (paper sections, technical reports, review articles) and must avoid characteristic LLM output patterns that reduce credibility and readability.
+
+## Procedure
+
+### Structure
+- Do NOT use bullet lists in running prose. Convert lists into flowing paragraphs with explicit logical connectives.
+- Do NOT start consecutive sentences with the same word or syntactic pattern.
+- Do NOT use inline mini-headings (e.g., "**Key insight:**") inside a paragraph.
+
+### Word Choice
+- Do NOT use vague intensifiers: "significantly", "notably", "importantly", "interestingly" without quantitative backing.
+- Do NOT use hedging fillers: "it is worth noting that", "it should be mentioned that" — just state the fact.
+- Do NOT use LLM-signature words: "leverage", "utilize", "facilitate", "cutting-edge", "state-of-the-art" (unless citing a specific benchmark), "delve", "crucial", "paramount".
+- Do NOT use em-dashes (—) as sentence connectors in formal prose; prefer semicolons, periods, or subordinate clauses.
+
+### Claims and Evidence
+- Do NOT make factual claims without a citation or direct experimental evidence. Every assertion of superiority, novelty, or importance must point to data.
+- Do NOT write "as shown in Table X" without verifying the table actually supports the specific claim.
+- Do NOT use "outperforms" or "superior to" without specifying the metric, dataset, and margin.
+
+### Conciseness
+- Do NOT pad sentences with unnecessary relative clauses. "The method that we propose" → "Our method".
+- Do NOT repeat the same information in both the introduction and the abstract with trivially different wording.
+- Do NOT add a summary paragraph at the end of each section that merely restates what was just said.
+
+### Honesty of Tone
+- Do NOT overstate contributions. If the improvement is 0.3%, say so plainly — do not frame it as "substantial".
+- Do NOT use passive voice to obscure agency when the agent matters. "The experiment was conducted" → "We ran the experiment".
+- Do NOT use "we believe" or "we feel" in place of evidence-backed claims.
+
+## Retrieval Cues
+- Drafting or editing any section of a research paper.
+- Reviewing AI-generated prose for publication readiness.
+- Polishing text to remove LLM-signature phrasing.
+- Ensuring claims are properly grounded in evidence.


### PR DESCRIPTION
## Summary
- Adds 3 new procedural/tie skills addressing issue #61 ("AI scientist的100种死法")
- **research-integrity-antipatterns**: deceptive practices to reject in paper writing (hidden compute, cherry-picked evals, rebranding)
- **scientific-prose-style-rules**: LLM writing antipatterns to avoid (hedging, bullet-list prose, signature words)
- **ai-agent-discipline**: operational failure modes to guard against (fake verification, premature stopping, convention drift)

Closes #61

## Sources
- [hzwer/WritingAIPaper/NotGoodIdeas.md](https://github.com/hzwer/WritingAIPaper/blob/main/NotGoodIdeas.md)
- [yzhao062/agent-style](https://github.com/yzhao062/agent-style)
- Practitioner field reports on Claude/GPT failure modes (2024-2026)

## Test plan
- [ ] Skills follow the extract-knowhow format (memory_type/procedural/tie with frontmatter)
- [ ] Consistent with existing skills in `skills/` directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)