### PR TITLE
fix: update AI settings deep-link URLs in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,9 @@ Enable memory so the AI can access your history:
 
 | Platform | How to enable | Settings link |
 |----------|--------------|---------------|
-| **ChatGPT** | Settings > Personalization > turn on **Memory** and **Reference chat history** | [Settings](https://chatgpt.com/settings) |
+| **ChatGPT** | Settings > Personalization > turn on **Memory** and **Reference chat history** | [Settings](https://chatgpt.com/#settings/Personalization) |
 | **Claude** | Settings > Capabilities > turn on **Memory** | [Settings](https://claude.ai/settings/capabilities) |
-| **Gemini** | Settings > Personal context > turn on **Your past chats with Gemini** | [Settings](https://gemini.google.com/settings) |
+| **Gemini** | Settings > Personal context > turn on **Your past chats with Gemini** | [Settings](https://gemini.google.com/app/settings) |
 
 Then paste this prompt into a **new conversation**:
 


### PR DESCRIPTION
## Summary
- Update ChatGPT link to `https://chatgpt.com/#settings/Personalization` (direct deep-link)
- Update Gemini link to `https://gemini.google.com/app/settings` (correct path)
- Claude link was already correct

## Test plan
- [x] Verify all 3 settings links in the readme open the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)