### PR TITLE
add: Gemini brain as new scan source for extract-knowhow

### DIFF
--- a/extract-knowhow/scripts/format-session.js
+++ b/extract-knowhow/scripts/format-session.js
@@ -702,23 +702,38 @@ function formatGeminiSession(dirPath) {
     messageCount += 1;
   }
 
-  // Read resolved snapshots in order — these show the session progression
-  const resolvedFiles = fs.readdirSync(dirPath)
-    .filter((f) => /\.resolved\.\d+$/.test(f))
-    .sort((a, b) => {
-      const numA = parseInt(a.match(/\.(\d+)$/)[1], 10);
-      const numB = parseInt(b.match(/\.(\d+)$/)[1], 10);
-      return numA - numB;
-    });
-
-  for (const rf of resolvedFiles) {
-    try {
-      const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
-      const baseName = rf.replace(/\.resolved\.\d+$/, '');
-      const label = baseName.replace(/\.md$/, '').replace(/_/g, ' ');
-      lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
-      messageCount += 1;
-    } catch {}
+  // Read resolved snapshots grouped by artifact, each in sequence order.
+  // Gemini uses independent .resolved.N sequences per artifact (e.g.
+  // task.md.resolved.0..5 and walkthrough.md.resolved.0); interleaving
+  // by number alone would jumble the timeline.
+  const allDirFiles = fs.readdirSync(dirPath);
+  const resolvedByArtifact = new Map();
+  for (const f of allDirFiles) {
+    const m = f.match(/^(.+)\.resolved\.(\d+)$/);
+    if (!m) continue;
+    const artifact = m[1];
+    const seq = parseInt(m[2], 10);
+    if (!resolvedByArtifact.has(artifact)) resolvedByArtifact.set(artifact, []);
+    resolvedByArtifact.get(artifact).push({ file: f, seq });
+  }
+  // Emit task snapshots first, then plan, then walkthrough, then others
+  const artifactOrder = ['task.md', 'implementation_plan.md', 'walkthrough.md'];
+  const sortedArtifacts = [...resolvedByArtifact.keys()].sort((a, b) => {
+    const ai = artifactOrder.indexOf(a);
+    const bi = artifactOrder.indexOf(b);
+    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+  });
+  for (const artifact of sortedArtifacts) {
+    const snapshots = resolvedByArtifact.get(artifact);
+    snapshots.sort((a, b) => a.seq - b.seq);
+    const label = artifact.replace(/\.md$/, '').replace(/_/g, ' ');
+    for (const { file: rf } of snapshots) {
+      try {
+        const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
+        lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
+        messageCount += 1;
+      } catch {}
+    }
   }
 
   // Read walkthrough.md — the session's summary/outcome

--- a/extract-knowhow/scripts/format-session.js
+++ b/extract-knowhow/scripts/format-session.js
@@ -2,10 +2,11 @@
 /**
  * format-session.js
  *
- * Preprocess a raw Claude Code or Codex .jsonl session file into
- * compact text optimized for research skill extraction.
+ * Preprocess a raw Claude Code or Codex .jsonl session file, or a
+ * Gemini brain entry directory, into compact text optimized for
+ * research skill extraction.
  *
- * Supports both Claude Code and Codex JSONL formats.
+ * Supports Claude Code JSONL, Codex JSONL, and Gemini brain formats.
  *
  * Design principle: We're extracting HUMAN tacit knowledge. The human's
  * inputs, corrections, and decisions are the signal. AI outputs and tool
@@ -653,6 +654,88 @@ function formatSession(jsonlPath) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Gemini brain entry formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a Gemini brain entry directory into extraction-ready text.
+ *
+ * Brain entries contain task.md, implementation_plan.md, walkthrough.md,
+ * plus .resolved.N snapshots showing progression. We reconstruct a
+ * session narrative from these artifacts.
+ */
+function formatGeminiSession(dirPath) {
+  const lines = [];
+  let startTimestamp = null;
+  let messageCount = 0;
+
+  // Collect metadata timestamps
+  const metaFiles = fs.readdirSync(dirPath).filter((f) => f.endsWith('.metadata.json'));
+  const timestamps = [];
+  for (const mf of metaFiles) {
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, mf), 'utf-8'));
+      if (meta.updatedAt) timestamps.push(meta.updatedAt);
+      if (meta.summary) {
+        lines.push(`[CONTEXT]: ${truncate(meta.summary, USER_MAX_CHARS)}`);
+        messageCount += 1;
+      }
+    } catch {}
+  }
+  timestamps.sort();
+  if (timestamps.length > 0) startTimestamp = timestamps[0];
+
+  // Read task.md — the session's goal
+  const taskFile = path.join(dirPath, 'task.md');
+  if (fs.existsSync(taskFile)) {
+    const taskContent = fs.readFileSync(taskFile, 'utf-8').trim();
+    lines.push(`USER: ${truncate(taskContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  // Read implementation_plan.md — the AI's plan
+  const planFile = path.join(dirPath, 'implementation_plan.md');
+  if (fs.existsSync(planFile)) {
+    const planContent = fs.readFileSync(planFile, 'utf-8').trim();
+    lines.push(`ASSISTANT: ${truncate(planContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  // Read resolved snapshots in order — these show the session progression
+  const resolvedFiles = fs.readdirSync(dirPath)
+    .filter((f) => /\.resolved\.\d+$/.test(f))
+    .sort((a, b) => {
+      const numA = parseInt(a.match(/\.(\d+)$/)[1], 10);
+      const numB = parseInt(b.match(/\.(\d+)$/)[1], 10);
+      return numA - numB;
+    });
+
+  for (const rf of resolvedFiles) {
+    try {
+      const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
+      const baseName = rf.replace(/\.resolved\.\d+$/, '');
+      const label = baseName.replace(/\.md$/, '').replace(/_/g, ' ');
+      lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
+      messageCount += 1;
+    } catch {}
+  }
+
+  // Read walkthrough.md — the session's summary/outcome
+  const walkthroughFile = path.join(dirPath, 'walkthrough.md');
+  if (fs.existsSync(walkthroughFile)) {
+    const walkthroughContent = fs.readFileSync(walkthroughFile, 'utf-8').trim();
+    lines.push(`ASSISTANT: ${truncate(walkthroughContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  return {
+    text: lines.join('\n'),
+    startTimestamp,
+    messageCount,
+  };
+}
+
 function splitIntoSegments(text) {
   if (text.length <= SEGMENT_THRESHOLD) return [text];
   const lines = text.split('\n');
@@ -677,7 +760,7 @@ function splitIntoSegments(text) {
 if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.length < 2) {
-    console.error('Usage: format-session.js <input.jsonl> <output.txt>');
+    console.error('Usage: format-session.js <input.jsonl|gemini-brain-dir> <output.txt>');
     process.exit(1);
   }
 
@@ -685,12 +768,16 @@ if (require.main === module) {
   const outputPath = path.resolve(args[1]);
 
   if (!fs.existsSync(inputPath)) {
-    console.error(`Error: input file not found: ${inputPath}`);
+    console.error(`Error: input not found: ${inputPath}`);
     process.exit(1);
   }
 
   try {
-    const { text, startTimestamp, messageCount } = formatSession(inputPath);
+    // Detect Gemini brain entry (directory with task.md) vs JSONL file
+    const isGemini = fs.statSync(inputPath).isDirectory() && fs.existsSync(path.join(inputPath, 'task.md'));
+    const { text, startTimestamp, messageCount } = isGemini
+      ? formatGeminiSession(inputPath)
+      : formatSession(inputPath);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
     const segments = splitIntoSegments(text);
@@ -723,7 +810,8 @@ if (require.main === module) {
 }
 
 module.exports = {
-  formatSession, splitIntoSegments, extractMessage: extractMessageClaude,
+  formatSession, formatGeminiSession, splitIntoSegments,
+  extractMessage: extractMessageClaude,
   extractMessageCodex, detectFormat, truncate,
   USER_MAX_CHARS, ASSISTANT_MAX_CHARS, SEGMENT_THRESHOLD, SEGMENT_SIZE,
 };

--- a/extract-knowhow/scripts/format-session.js
+++ b/extract-knowhow/scripts/format-session.js
@@ -702,38 +702,29 @@ function formatGeminiSession(dirPath) {
     messageCount += 1;
   }
 
-  // Read resolved snapshots grouped by artifact, each in sequence order.
-  // Gemini uses independent .resolved.N sequences per artifact (e.g.
-  // task.md.resolved.0..5 and walkthrough.md.resolved.0); interleaving
-  // by number alone would jumble the timeline.
+  // Read resolved snapshots sorted by file mtime for correct chronology.
+  // Gemini uses independent .resolved.N counters per artifact, so sorting
+  // by mtime across all artifacts preserves the actual decision sequence.
   const allDirFiles = fs.readdirSync(dirPath);
-  const resolvedByArtifact = new Map();
+  const resolvedSnapshots = [];
   for (const f of allDirFiles) {
     const m = f.match(/^(.+)\.resolved\.(\d+)$/);
     if (!m) continue;
     const artifact = m[1];
-    const seq = parseInt(m[2], 10);
-    if (!resolvedByArtifact.has(artifact)) resolvedByArtifact.set(artifact, []);
-    resolvedByArtifact.get(artifact).push({ file: f, seq });
+    const fullPath = path.join(dirPath, f);
+    let mtime = 0;
+    try { mtime = fs.statSync(fullPath).mtimeMs; } catch {}
+    resolvedSnapshots.push({ file: f, artifact, mtime });
   }
-  // Emit task snapshots first, then plan, then walkthrough, then others
-  const artifactOrder = ['task.md', 'implementation_plan.md', 'walkthrough.md'];
-  const sortedArtifacts = [...resolvedByArtifact.keys()].sort((a, b) => {
-    const ai = artifactOrder.indexOf(a);
-    const bi = artifactOrder.indexOf(b);
-    return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
-  });
-  for (const artifact of sortedArtifacts) {
-    const snapshots = resolvedByArtifact.get(artifact);
-    snapshots.sort((a, b) => a.seq - b.seq);
-    const label = artifact.replace(/\.md$/, '').replace(/_/g, ' ');
-    for (const { file: rf } of snapshots) {
-      try {
-        const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
-        lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
-        messageCount += 1;
-      } catch {}
-    }
+  resolvedSnapshots.sort((a, b) => a.mtime - b.mtime);
+
+  for (const { file: rf, artifact } of resolvedSnapshots) {
+    try {
+      const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
+      const label = artifact.replace(/\.md$/, '').replace(/_/g, ' ');
+      lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
+      messageCount += 1;
+    } catch {}
   }
 
   // Read walkthrough.md — the session's summary/outcome

--- a/extract-knowhow/scripts/scan-sessions.js
+++ b/extract-knowhow/scripts/scan-sessions.js
@@ -4,7 +4,7 @@
  *
  * Stage 1 + 2 of /extract-knowhow, as a single deterministic script.
  *
- * Discovers Claude Code and Codex session files, extracts per-session
+ * Discovers Claude Code, Codex, and Gemini brain session files, extracts per-session
  * metadata, filters out garbage (too-small, too-short, sub-agent, duplicate),
  * groups by project path, and emits a work list that the AI phase iterates
  * over.
@@ -79,7 +79,36 @@ function discoverCodex() {
   return [...archived, ...sessions];
 }
 
+/**
+ * Discover Gemini brain entries at ~/.gemini/antigravity/brain/<uuid>/.
+ * Each non-empty UUID directory is treated as one session.
+ * Returns an array of directory paths (not individual files).
+ */
+function discoverGemini() {
+  const root = path.join(os.homedir(), '.gemini', 'antigravity', 'brain');
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  const results = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch (err) {
+    return results;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory() || !UUID_RE.test(e.name)) continue;
+    const dir = path.join(root, e.name);
+    const taskFile = path.join(dir, 'task.md');
+    if (!fs.existsSync(taskFile)) continue;
+    results.push(dir);
+  }
+  return results;
+}
+
 function extractSessionId(filePath, source) {
+  if (source === 'gemini') {
+    // filePath is the brain entry directory; its basename is the UUID
+    return path.basename(filePath);
+  }
   const base = path.basename(filePath, '.jsonl');
   if (source === 'codex') {
     const m = base.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/);
@@ -258,6 +287,96 @@ function extractMeta(filePath) {
   };
 }
 
+/**
+ * Extract metadata from a Gemini brain entry directory.
+ * Brain entries contain task.md, implementation_plan.md, walkthrough.md,
+ * plus .metadata.json sidecars and .resolved.N historical snapshots.
+ */
+function extractMetaGemini(dirPath) {
+  const taskFile = path.join(dirPath, 'task.md');
+  const taskContent = fs.readFileSync(taskFile, 'utf-8');
+  const titleMatch = taskContent.match(/^#\s+(.+)/m);
+  const firstPrompt = titleMatch ? titleMatch[1].trim() : null;
+
+  // Compute combined size of all .md files in the entry
+  const mdFiles = fs.readdirSync(dirPath).filter(
+    (f) => f.endsWith('.md') && !f.endsWith('.resolved') && !f.match(/\.resolved\.\d+$/)
+  );
+  let totalSize = 0;
+  for (const f of mdFiles) {
+    try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
+  }
+
+  // Count resolved snapshots as a proxy for user interactions
+  const resolvedFiles = fs.readdirSync(dirPath).filter(
+    (f) => /\.resolved\.\d+$/.test(f)
+  );
+  const userMessageCount = Math.max(resolvedFiles.length, mdFiles.length);
+
+  // Extract timestamps from metadata sidecars
+  let startTimestamp = null;
+  let endTimestamp = null;
+  for (const f of fs.readdirSync(dirPath)) {
+    if (!f.endsWith('.metadata.json')) continue;
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, f), 'utf-8'));
+      const ts = meta.updatedAt || null;
+      if (ts) {
+        if (!startTimestamp || ts < startTimestamp) startTimestamp = ts;
+        if (!endTimestamp || ts > endTimestamp) endTimestamp = ts;
+      }
+    } catch {}
+  }
+
+  // Extract project path from file:// links in resolved files or plan
+  let cwd = null;
+  const planFile = path.join(dirPath, 'implementation_plan.md');
+  const searchFiles = [planFile, taskFile];
+  for (const sf of searchFiles) {
+    if (cwd) break;
+    try {
+      const content = fs.readFileSync(sf, 'utf-8');
+      const fileMatch = content.match(/file:\/\/\/([\w/._-]+\/[\w._-]+)/);
+      if (fileMatch) {
+        const filePath = '/' + fileMatch[1];
+        // Walk up to find a likely project root (dir with package.json, Cargo.toml, etc.)
+        const parts = filePath.split('/');
+        for (let i = parts.length - 1; i >= 2; i--) {
+          const candidate = parts.slice(0, i).join('/');
+          try {
+            const entries = fs.readdirSync(candidate);
+            if (entries.some((e) => ['package.json', 'Cargo.toml', 'go.mod', 'pyproject.toml', '.git'].includes(e))) {
+              cwd = candidate;
+              break;
+            }
+          } catch {}
+        }
+        if (!cwd) cwd = path.dirname(filePath);
+      }
+    } catch {}
+  }
+
+  let durationMinutes = 0;
+  if (startTimestamp && endTimestamp) {
+    const dt = new Date(endTimestamp).getTime() - new Date(startTimestamp).getTime();
+    if (!Number.isNaN(dt) && dt > 0) {
+      durationMinutes = Math.round(dt / 60000);
+    }
+  }
+
+  return {
+    file_size: totalSize,
+    is_sub_agent: false,
+    first_prompt: firstPrompt ? firstPrompt.substring(0, 500) : null,
+    sampled_prompts: [],
+    user_message_count: userMessageCount,
+    cwd,
+    start_timestamp: startTimestamp,
+    end_timestamp: endTimestamp,
+    duration_minutes: durationMinutes,
+  };
+}
+
 function metaCachePath(sessionId) {
   return path.join(META_CACHE_DIR, `${sessionId}.json`);
 }
@@ -283,6 +402,7 @@ function scan() {
   const candidates = [
     ...discoverClaude().map((f) => ({ file: f, source: 'claude' })),
     ...discoverCodex().map((f) => ({ file: f, source: 'codex' })),
+    ...discoverGemini().map((f) => ({ file: f, source: 'gemini' })),
   ];
 
   const skipped = {
@@ -296,23 +416,28 @@ function scan() {
   const byFingerprint = new Map();
 
   for (const { file, source } of candidates) {
-    let stats;
+    // For Gemini, `file` is a directory path; size check uses task.md
+    let fileSize;
     try {
-      stats = fs.statSync(file);
+      if (source === 'gemini') {
+        fileSize = fs.statSync(path.join(file, 'task.md')).size;
+      } else {
+        fileSize = fs.statSync(file).size;
+      }
     } catch (err) {
       skipped.unreadable += 1;
       continue;
     }
-    if (stats.size < MIN_FILE_SIZE) {
+    if (fileSize < MIN_FILE_SIZE) {
       skipped.tooSmall += 1;
       continue;
     }
 
     const sessionId = extractSessionId(file, source);
-    let meta = loadCachedMeta(sessionId, stats.size);
+    let meta = loadCachedMeta(sessionId, fileSize);
     if (!meta) {
       try {
-        meta = extractMeta(file);
+        meta = source === 'gemini' ? extractMetaGemini(file) : extractMeta(file);
       } catch (err) {
         skipped.unreadable += 1;
         continue;

--- a/extract-knowhow/scripts/scan-sessions.js
+++ b/extract-knowhow/scripts/scan-sessions.js
@@ -298,14 +298,17 @@ function extractMetaGemini(dirPath) {
   const titleMatch = taskContent.match(/^#\s+(.+)/m);
   const firstPrompt = titleMatch ? titleMatch[1].trim() : null;
 
-  // Compute combined size of all .md files in the entry
-  const mdFiles = fs.readdirSync(dirPath).filter(
-    (f) => f.endsWith('.md') && !f.endsWith('.resolved') && !f.match(/\.resolved\.\d+$/)
-  );
+  const allFiles = fs.readdirSync(dirPath);
+
+  // Compute combined size of all files (matches the cache key in scan())
   let totalSize = 0;
-  for (const f of mdFiles) {
+  for (const f of allFiles) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
+
+  const mdFiles = allFiles.filter(
+    (f) => f.endsWith('.md') && !f.endsWith('.resolved') && !/\.resolved\.\d+$/.test(f)
+  );
 
   // Count resolved snapshots as a proxy for user interactions
   const resolvedFiles = fs.readdirSync(dirPath).filter(
@@ -422,16 +425,14 @@ function scan() {
   const byFingerprint = new Map();
 
   for (const { file, source } of candidates) {
-    // For Gemini, `file` is a directory; use combined .md file size
-    // so entries with short task.md but substantial plan/walkthrough pass
+    // For Gemini, `file` is a directory; sum all file sizes so the cache
+    // key invalidates when any artifact changes (resolved, metadata, etc.)
     let fileSize;
     try {
       if (source === 'gemini') {
         fileSize = 0;
         for (const f of fs.readdirSync(file)) {
-          if (f.endsWith('.md') && !f.endsWith('.resolved') && !/\.resolved\.\d+$/.test(f)) {
-            fileSize += fs.statSync(path.join(file, f)).size;
-          }
+          try { fileSize += fs.statSync(path.join(file, f)).size; } catch {}
         }
       } else {
         fileSize = fs.statSync(file).size;
@@ -473,11 +474,17 @@ function scan() {
       continue;
     }
 
-    const projectPath =
-      meta.cwd ||
-      (source === 'claude'
-        ? claudeProjectDirName(file)
-        : path.basename(path.dirname(file)));
+    let projectPath = meta.cwd;
+    if (!projectPath) {
+      if (source === 'claude') {
+        projectPath = claudeProjectDirName(file);
+      } else if (source === 'gemini') {
+        // Use gemini/<uuid> to keep link-less entries separate
+        projectPath = `gemini/${path.basename(file)}`;
+      } else {
+        projectPath = path.basename(path.dirname(file));
+      }
+    }
 
     const record = {
       session_id: sessionId,

--- a/extract-knowhow/scripts/scan-sessions.js
+++ b/extract-knowhow/scripts/scan-sessions.js
@@ -310,11 +310,13 @@ function extractMetaGemini(dirPath) {
     (f) => f.endsWith('.md') && !f.endsWith('.resolved') && !/\.resolved\.\d+$/.test(f)
   );
 
-  // Count resolved snapshots as a proxy for user interactions
-  const resolvedFiles = fs.readdirSync(dirPath).filter(
+  // Count resolved snapshots as a proxy for user interactions.
+  // Only resolved files indicate real iterative work — the base .md files
+  // (task, plan, walkthrough) are often auto-generated in a single shot.
+  const resolvedFiles = allFiles.filter(
     (f) => /\.resolved\.\d+$/.test(f)
   );
-  const userMessageCount = Math.max(resolvedFiles.length, mdFiles.length);
+  const userMessageCount = resolvedFiles.length;
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;

--- a/extract-knowhow/scripts/scan-sessions.js
+++ b/extract-knowhow/scripts/scan-sessions.js
@@ -328,10 +328,16 @@ function extractMetaGemini(dirPath) {
     } catch {}
   }
 
-  // Extract project path from file:// links in resolved files or plan
+  // Extract project path from file:// links in plan, task, and resolved snapshots
   let cwd = null;
   const planFile = path.join(dirPath, 'implementation_plan.md');
   const searchFiles = [planFile, taskFile];
+  // Also search resolved snapshots which may contain file:// links
+  for (const f of fs.readdirSync(dirPath)) {
+    if (/\.resolved(\.\d+)?$/.test(f)) {
+      searchFiles.push(path.join(dirPath, f));
+    }
+  }
   for (const sf of searchFiles) {
     if (cwd) break;
     try {
@@ -416,11 +422,17 @@ function scan() {
   const byFingerprint = new Map();
 
   for (const { file, source } of candidates) {
-    // For Gemini, `file` is a directory path; size check uses task.md
+    // For Gemini, `file` is a directory; use combined .md file size
+    // so entries with short task.md but substantial plan/walkthrough pass
     let fileSize;
     try {
       if (source === 'gemini') {
-        fileSize = fs.statSync(path.join(file, 'task.md')).size;
+        fileSize = 0;
+        for (const f of fs.readdirSync(file)) {
+          if (f.endsWith('.md') && !f.endsWith('.resolved') && !/\.resolved\.\d+$/.test(f)) {
+            fileSize += fs.statSync(path.join(file, f)).size;
+          }
+        }
       } else {
         fileSize = fs.statSync(file).size;
       }


### PR DESCRIPTION
## Summary

- Adds Gemini CLI brain entries (`~/.gemini/antigravity/brain/<uuid>/`) as a third session source alongside Claude Code and Codex
- Brain entries use markdown artifacts (task.md, implementation_plan.md, walkthrough.md) with metadata sidecars and `.resolved.N` historical snapshots instead of JSONL
- `scan-sessions.js`: `discoverGemini()` finds UUID dirs with task.md, `extractMetaGemini()` parses metadata from sidecars and `file://` links in all artifacts including snapshots
- `format-session.js`: `formatGeminiSession()` reconstructs a session narrative from the markdown artifacts in the same USER/ASSISTANT/CONTEXT format the extraction pipeline expects, with snapshots sorted chronologically by mtime

Closes #28 (partial — addresses the Gemini brain integration path; broader IDE/schema discussions remain open)

## Test plan

- [x] Verified scan discovers 14 Gemini sessions from local brain entries
- [x] Verified format produces valid extraction-ready text with correct chronological snapshot ordering
- [x] Verified project path inference from `file://` links in task, plan, and snapshot files
- [x] Verified one-shot entries (no resolved snapshots) are correctly filtered out
- [x] Verified link-less entries get unique `gemini/<uuid>` project paths instead of collapsing into `brain`
- [x] 3 rounds of codex review — all P1/P2/P3 findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)