### PR TITLE
add: Gemini brain as new scan source (rebased)

### DIFF
--- a/researchskills-extract/scripts/format-session.js
+++ b/researchskills-extract/scripts/format-session.js
@@ -686,25 +686,11 @@ function formatGeminiSession(dirPath) {
   timestamps.sort();
   if (timestamps.length > 0) startTimestamp = timestamps[0];
 
-  // Read task.md — the session's goal
-  const taskFile = path.join(dirPath, 'task.md');
-  if (fs.existsSync(taskFile)) {
-    const taskContent = fs.readFileSync(taskFile, 'utf-8').trim();
-    lines.push(`USER: ${truncate(taskContent, USER_MAX_CHARS)}`);
-    messageCount += 1;
-  }
-
-  // Read implementation_plan.md — the AI's plan
-  const planFile = path.join(dirPath, 'implementation_plan.md');
-  if (fs.existsSync(planFile)) {
-    const planContent = fs.readFileSync(planFile, 'utf-8').trim();
-    lines.push(`ASSISTANT: ${truncate(planContent, USER_MAX_CHARS)}`);
-    messageCount += 1;
-  }
-
-  // Read resolved snapshots sorted by file mtime for correct chronology.
+  // Read resolved snapshots first, sorted by file mtime for correct chronology.
   // Gemini uses independent .resolved.N counters per artifact, so sorting
   // by mtime across all artifacts preserves the actual decision sequence.
+  // Current task.md/plan are emitted AFTER snapshots since snapshots are
+  // older states and current files represent the latest state.
   const allDirFiles = fs.readdirSync(dirPath);
   const resolvedSnapshots = [];
   for (const f of allDirFiles) {
@@ -725,6 +711,22 @@ function formatGeminiSession(dirPath) {
       lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
       messageCount += 1;
     } catch {}
+  }
+
+  // Read task.md — the session's current/final goal (after snapshots)
+  const taskFile = path.join(dirPath, 'task.md');
+  if (fs.existsSync(taskFile)) {
+    const taskContent = fs.readFileSync(taskFile, 'utf-8').trim();
+    lines.push(`USER: ${truncate(taskContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  // Read implementation_plan.md — the AI's current/final plan
+  const planFile = path.join(dirPath, 'implementation_plan.md');
+  if (fs.existsSync(planFile)) {
+    const planContent = fs.readFileSync(planFile, 'utf-8').trim();
+    lines.push(`ASSISTANT: ${truncate(planContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
   }
 
   // Read walkthrough.md — the session's summary/outcome

--- a/researchskills-extract/scripts/format-session.js
+++ b/researchskills-extract/scripts/format-session.js
@@ -670,21 +670,25 @@ function formatGeminiSession(dirPath) {
   let startTimestamp = null;
   let messageCount = 0;
 
-  // Collect metadata timestamps
+  // Collect metadata timestamps and summaries, sorted by updatedAt for
+  // deterministic output across machines (readdirSync order varies).
   const metaFiles = fs.readdirSync(dirPath).filter((f) => f.endsWith('.metadata.json'));
-  const timestamps = [];
+  const metaEntries = [];
   for (const mf of metaFiles) {
     try {
       const meta = JSON.parse(fs.readFileSync(path.join(dirPath, mf), 'utf-8'));
-      if (meta.updatedAt) timestamps.push(meta.updatedAt);
-      if (meta.summary) {
-        lines.push(`[CONTEXT]: ${truncate(meta.summary, USER_MAX_CHARS)}`);
-        messageCount += 1;
-      }
+      metaEntries.push({ updatedAt: meta.updatedAt || '', summary: meta.summary || '' });
     } catch {}
   }
-  timestamps.sort();
+  metaEntries.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+  const timestamps = metaEntries.filter((e) => e.updatedAt).map((e) => e.updatedAt);
   if (timestamps.length > 0) startTimestamp = timestamps[0];
+  for (const entry of metaEntries) {
+    if (entry.summary) {
+      lines.push(`[CONTEXT]: ${truncate(entry.summary, USER_MAX_CHARS)}`);
+      messageCount += 1;
+    }
+  }
 
   // Read resolved snapshots first, sorted by file mtime for correct chronology.
   // Gemini uses independent .resolved.N counters per artifact, so sorting

--- a/researchskills-extract/scripts/format-session.js
+++ b/researchskills-extract/scripts/format-session.js
@@ -713,11 +713,14 @@ function formatGeminiSession(dirPath) {
     } catch {}
   }
 
-  // Read task.md — the session's current/final goal (after snapshots)
+  // Read task.md — the session's current/final goal (after snapshots).
+  // Labeled as CONTEXT rather than USER because Gemini expands task.md with
+  // generated checklists, substeps, and completion markers. The user's
+  // original intent is the title line; the rest is agent-authored.
   const taskFile = path.join(dirPath, 'task.md');
   if (fs.existsSync(taskFile)) {
     const taskContent = fs.readFileSync(taskFile, 'utf-8').trim();
-    lines.push(`USER: ${truncate(taskContent, USER_MAX_CHARS)}`);
+    lines.push(`[CONTEXT]: ${truncate(taskContent, USER_MAX_CHARS)}`);
     messageCount += 1;
   }
 

--- a/researchskills-extract/scripts/format-session.js
+++ b/researchskills-extract/scripts/format-session.js
@@ -728,7 +728,7 @@ function formatGeminiSession(dirPath) {
   const planFile = path.join(dirPath, 'implementation_plan.md');
   if (fs.existsSync(planFile)) {
     const planContent = fs.readFileSync(planFile, 'utf-8').trim();
-    lines.push(`ASSISTANT: ${truncate(planContent, USER_MAX_CHARS)}`);
+    lines.push(`ASSISTANT: ${truncate(planContent, ASSISTANT_MAX_CHARS)}`);
     messageCount += 1;
   }
 
@@ -736,7 +736,7 @@ function formatGeminiSession(dirPath) {
   const walkthroughFile = path.join(dirPath, 'walkthrough.md');
   if (fs.existsSync(walkthroughFile)) {
     const walkthroughContent = fs.readFileSync(walkthroughFile, 'utf-8').trim();
-    lines.push(`ASSISTANT: ${truncate(walkthroughContent, USER_MAX_CHARS)}`);
+    lines.push(`ASSISTANT: ${truncate(walkthroughContent, ASSISTANT_MAX_CHARS)}`);
     messageCount += 1;
   }
 

--- a/researchskills-extract/scripts/format-session.js
+++ b/researchskills-extract/scripts/format-session.js
@@ -2,10 +2,11 @@
 /**
  * format-session.js
  *
- * Preprocess a raw Claude Code or Codex .jsonl session file into
- * compact text optimized for research skill extraction.
+ * Preprocess a raw Claude Code or Codex .jsonl session file, or a
+ * Gemini brain entry directory, into compact text optimized for
+ * research skill extraction.
  *
- * Supports both Claude Code and Codex JSONL formats.
+ * Supports Claude Code JSONL, Codex JSONL, and Gemini brain formats.
  *
  * Design principle: We're extracting HUMAN tacit knowledge. The human's
  * inputs, corrections, and decisions are the signal. AI outputs and tool
@@ -653,6 +654,94 @@ function formatSession(jsonlPath) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Gemini brain entry formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a Gemini brain entry directory into extraction-ready text.
+ *
+ * Brain entries contain task.md, implementation_plan.md, walkthrough.md,
+ * plus .resolved.N snapshots showing progression. We reconstruct a
+ * session narrative from these artifacts.
+ */
+function formatGeminiSession(dirPath) {
+  const lines = [];
+  let startTimestamp = null;
+  let messageCount = 0;
+
+  // Collect metadata timestamps
+  const metaFiles = fs.readdirSync(dirPath).filter((f) => f.endsWith('.metadata.json'));
+  const timestamps = [];
+  for (const mf of metaFiles) {
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, mf), 'utf-8'));
+      if (meta.updatedAt) timestamps.push(meta.updatedAt);
+      if (meta.summary) {
+        lines.push(`[CONTEXT]: ${truncate(meta.summary, USER_MAX_CHARS)}`);
+        messageCount += 1;
+      }
+    } catch {}
+  }
+  timestamps.sort();
+  if (timestamps.length > 0) startTimestamp = timestamps[0];
+
+  // Read task.md — the session's goal
+  const taskFile = path.join(dirPath, 'task.md');
+  if (fs.existsSync(taskFile)) {
+    const taskContent = fs.readFileSync(taskFile, 'utf-8').trim();
+    lines.push(`USER: ${truncate(taskContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  // Read implementation_plan.md — the AI's plan
+  const planFile = path.join(dirPath, 'implementation_plan.md');
+  if (fs.existsSync(planFile)) {
+    const planContent = fs.readFileSync(planFile, 'utf-8').trim();
+    lines.push(`ASSISTANT: ${truncate(planContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  // Read resolved snapshots sorted by file mtime for correct chronology.
+  // Gemini uses independent .resolved.N counters per artifact, so sorting
+  // by mtime across all artifacts preserves the actual decision sequence.
+  const allDirFiles = fs.readdirSync(dirPath);
+  const resolvedSnapshots = [];
+  for (const f of allDirFiles) {
+    const m = f.match(/^(.+)\.resolved\.(\d+)$/);
+    if (!m) continue;
+    const artifact = m[1];
+    const fullPath = path.join(dirPath, f);
+    let mtime = 0;
+    try { mtime = fs.statSync(fullPath).mtimeMs; } catch {}
+    resolvedSnapshots.push({ file: f, artifact, mtime });
+  }
+  resolvedSnapshots.sort((a, b) => a.mtime - b.mtime);
+
+  for (const { file: rf, artifact } of resolvedSnapshots) {
+    try {
+      const content = fs.readFileSync(path.join(dirPath, rf), 'utf-8').trim();
+      const label = artifact.replace(/\.md$/, '').replace(/_/g, ' ');
+      lines.push(`[Snapshot: ${label}]: ${truncate(content, USER_MAX_CHARS)}`);
+      messageCount += 1;
+    } catch {}
+  }
+
+  // Read walkthrough.md — the session's summary/outcome
+  const walkthroughFile = path.join(dirPath, 'walkthrough.md');
+  if (fs.existsSync(walkthroughFile)) {
+    const walkthroughContent = fs.readFileSync(walkthroughFile, 'utf-8').trim();
+    lines.push(`ASSISTANT: ${truncate(walkthroughContent, USER_MAX_CHARS)}`);
+    messageCount += 1;
+  }
+
+  return {
+    text: lines.join('\n'),
+    startTimestamp,
+    messageCount,
+  };
+}
+
 function splitIntoSegments(text) {
   if (text.length <= SEGMENT_THRESHOLD) return [text];
   const lines = text.split('\n');
@@ -677,7 +766,7 @@ function splitIntoSegments(text) {
 if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.length < 2) {
-    console.error('Usage: format-session.js <input.jsonl> <output.txt>');
+    console.error('Usage: format-session.js <input.jsonl|gemini-brain-dir> <output.txt>');
     process.exit(1);
   }
 
@@ -685,12 +774,16 @@ if (require.main === module) {
   const outputPath = path.resolve(args[1]);
 
   if (!fs.existsSync(inputPath)) {
-    console.error(`Error: input file not found: ${inputPath}`);
+    console.error(`Error: input not found: ${inputPath}`);
     process.exit(1);
   }
 
   try {
-    const { text, startTimestamp, messageCount } = formatSession(inputPath);
+    // Detect Gemini brain entry (directory with task.md) vs JSONL file
+    const isGemini = fs.statSync(inputPath).isDirectory() && fs.existsSync(path.join(inputPath, 'task.md'));
+    const { text, startTimestamp, messageCount } = isGemini
+      ? formatGeminiSession(inputPath)
+      : formatSession(inputPath);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
     const segments = splitIntoSegments(text);
@@ -723,7 +816,8 @@ if (require.main === module) {
 }
 
 module.exports = {
-  formatSession, splitIntoSegments, extractMessage: extractMessageClaude,
+  formatSession, formatGeminiSession, splitIntoSegments,
+  extractMessage: extractMessageClaude,
   extractMessageCodex, detectFormat, truncate,
   USER_MAX_CHARS, ASSISTANT_MAX_CHARS, SEGMENT_THRESHOLD, SEGMENT_SIZE,
 };

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -4,7 +4,7 @@
  *
  * Stage 1 + 2 of /researchskills-extract, as a single deterministic script.
  *
- * Discovers Claude Code and Codex session files, extracts per-session
+ * Discovers Claude Code, Codex, and Gemini brain session files, extracts per-session
  * metadata, filters out garbage (too-small, too-short, sub-agent, duplicate),
  * groups by project path, and emits a work list that the AI phase iterates
  * over.
@@ -79,7 +79,36 @@ function discoverCodex() {
   return [...archived, ...sessions];
 }
 
+/**
+ * Discover Gemini brain entries at ~/.gemini/antigravity/brain/<uuid>/.
+ * Each non-empty UUID directory is treated as one session.
+ * Returns an array of directory paths (not individual files).
+ */
+function discoverGemini() {
+  const root = path.join(os.homedir(), '.gemini', 'antigravity', 'brain');
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  const results = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch (err) {
+    return results;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory() || !UUID_RE.test(e.name)) continue;
+    const dir = path.join(root, e.name);
+    const taskFile = path.join(dir, 'task.md');
+    if (!fs.existsSync(taskFile)) continue;
+    results.push(dir);
+  }
+  return results;
+}
+
 function extractSessionId(filePath, source) {
+  if (source === 'gemini') {
+    // filePath is the brain entry directory; its basename is the UUID
+    return path.basename(filePath);
+  }
   const base = path.basename(filePath, '.jsonl');
   if (source === 'codex') {
     const m = base.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/);
@@ -258,6 +287,103 @@ function extractMeta(filePath) {
   };
 }
 
+/**
+ * Extract metadata from a Gemini brain entry directory.
+ * Brain entries contain task.md, implementation_plan.md, walkthrough.md,
+ * plus .metadata.json sidecars and .resolved.N historical snapshots.
+ */
+function extractMetaGemini(dirPath) {
+  const taskFile = path.join(dirPath, 'task.md');
+  const taskContent = fs.readFileSync(taskFile, 'utf-8');
+  const titleMatch = taskContent.match(/^#\s+(.+)/m);
+  const firstPrompt = titleMatch ? titleMatch[1].trim() : null;
+
+  const allFiles = fs.readdirSync(dirPath);
+
+  // Compute combined size of all files (matches the cache key in scan())
+  let totalSize = 0;
+  for (const f of allFiles) {
+    try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
+  }
+
+  // Count resolved snapshots as a proxy for user interactions.
+  // Only resolved files indicate real iterative work — the base .md files
+  // (task, plan, walkthrough) are often auto-generated in a single shot.
+  const resolvedFiles = allFiles.filter(
+    (f) => /\.resolved\.\d+$/.test(f)
+  );
+  const userMessageCount = resolvedFiles.length;
+
+  // Extract timestamps from metadata sidecars
+  let startTimestamp = null;
+  let endTimestamp = null;
+  for (const f of allFiles) {
+    if (!f.endsWith('.metadata.json')) continue;
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, f), 'utf-8'));
+      const ts = meta.updatedAt || null;
+      if (ts) {
+        if (!startTimestamp || ts < startTimestamp) startTimestamp = ts;
+        if (!endTimestamp || ts > endTimestamp) endTimestamp = ts;
+      }
+    } catch {}
+  }
+
+  // Extract project path from file:// links in plan, task, and resolved snapshots
+  let cwd = null;
+  const planFile = path.join(dirPath, 'implementation_plan.md');
+  const searchFiles = [planFile, taskFile];
+  // Also search resolved snapshots which may contain file:// links
+  for (const f of allFiles) {
+    if (/\.resolved(\.\d+)?$/.test(f)) {
+      searchFiles.push(path.join(dirPath, f));
+    }
+  }
+  for (const sf of searchFiles) {
+    if (cwd) break;
+    try {
+      const content = fs.readFileSync(sf, 'utf-8');
+      const fileMatch = content.match(/file:\/\/\/([\w/._-]+\/[\w._-]+)/);
+      if (fileMatch) {
+        const filePath = '/' + fileMatch[1];
+        // Walk up to find a likely project root (dir with package.json, Cargo.toml, etc.)
+        const parts = filePath.split('/');
+        for (let i = parts.length - 1; i >= 2; i--) {
+          const candidate = parts.slice(0, i).join('/');
+          try {
+            const entries = fs.readdirSync(candidate);
+            if (entries.some((e) => ['package.json', 'Cargo.toml', 'go.mod', 'pyproject.toml', '.git'].includes(e))) {
+              cwd = candidate;
+              break;
+            }
+          } catch {}
+        }
+        if (!cwd) cwd = path.dirname(filePath);
+      }
+    } catch {}
+  }
+
+  let durationMinutes = 0;
+  if (startTimestamp && endTimestamp) {
+    const dt = new Date(endTimestamp).getTime() - new Date(startTimestamp).getTime();
+    if (!Number.isNaN(dt) && dt > 0) {
+      durationMinutes = Math.round(dt / 60000);
+    }
+  }
+
+  return {
+    file_size: totalSize,
+    is_sub_agent: false,
+    first_prompt: firstPrompt ? firstPrompt.substring(0, 500) : null,
+    sampled_prompts: [],
+    user_message_count: userMessageCount,
+    cwd,
+    start_timestamp: startTimestamp,
+    end_timestamp: endTimestamp,
+    duration_minutes: durationMinutes,
+  };
+}
+
 function metaCachePath(sessionId) {
   return path.join(META_CACHE_DIR, `${sessionId}.json`);
 }
@@ -283,6 +409,7 @@ function scan() {
   const candidates = [
     ...discoverClaude().map((f) => ({ file: f, source: 'claude' })),
     ...discoverCodex().map((f) => ({ file: f, source: 'codex' })),
+    ...discoverGemini().map((f) => ({ file: f, source: 'gemini' })),
   ];
 
   const skipped = {
@@ -296,23 +423,32 @@ function scan() {
   const byFingerprint = new Map();
 
   for (const { file, source } of candidates) {
-    let stats;
+    // For Gemini, `file` is a directory; sum all file sizes so the cache
+    // key invalidates when any artifact changes (resolved, metadata, etc.)
+    let fileSize;
     try {
-      stats = fs.statSync(file);
+      if (source === 'gemini') {
+        fileSize = 0;
+        for (const f of fs.readdirSync(file)) {
+          try { fileSize += fs.statSync(path.join(file, f)).size; } catch {}
+        }
+      } else {
+        fileSize = fs.statSync(file).size;
+      }
     } catch (err) {
       skipped.unreadable += 1;
       continue;
     }
-    if (stats.size < MIN_FILE_SIZE) {
+    if (fileSize < MIN_FILE_SIZE) {
       skipped.tooSmall += 1;
       continue;
     }
 
     const sessionId = extractSessionId(file, source);
-    let meta = loadCachedMeta(sessionId, stats.size);
+    let meta = loadCachedMeta(sessionId, fileSize);
     if (!meta) {
       try {
-        meta = extractMeta(file);
+        meta = source === 'gemini' ? extractMetaGemini(file) : extractMeta(file);
       } catch (err) {
         skipped.unreadable += 1;
         continue;
@@ -336,11 +472,17 @@ function scan() {
       continue;
     }
 
-    const projectPath =
-      meta.cwd ||
-      (source === 'claude'
-        ? claudeProjectDirName(file)
-        : path.basename(path.dirname(file)));
+    let projectPath = meta.cwd;
+    if (!projectPath) {
+      if (source === 'claude') {
+        projectPath = claudeProjectDirName(file);
+      } else if (source === 'gemini') {
+        // Use gemini/<uuid> to keep link-less entries separate
+        projectPath = `gemini/${path.basename(file)}`;
+      } else {
+        projectPath = path.basename(path.dirname(file));
+      }
+    }
 
     const record = {
       session_id: sessionId,

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -306,13 +306,15 @@ function extractMetaGemini(dirPath) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
 
-  // Count only task.md resolved snapshots as user turns.
+  // Count task.md resolved snapshots + the current task.md as user turns.
   // Plan/walkthrough snapshots are AI-generated artifacts — counting them
   // would let one-shot entries (with task+plan+walkthrough resolved.0) pass
-  // the MIN_USER_MESSAGES filter.
-  const userMessageCount = allFiles.filter(
+  // the MIN_USER_MESSAGES filter. The current task.md counts as one turn
+  // since formatGeminiSession() emits it alongside resolved snapshots.
+  const taskResolvedCount = allFiles.filter(
     (f) => /^task\.md\.resolved\.\d+$/.test(f)
   ).length;
+  const userMessageCount = taskResolvedCount + 1;
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;
@@ -371,16 +373,19 @@ function extractMetaGemini(dirPath) {
     }
   }
 
-  // Fallback: derive duration from resolved snapshot mtimes when metadata
-  // is singular (e.g. only task.md.metadata.json exists, yielding start==end)
+  // Fallback: derive duration from artifact mtimes when metadata is singular
+  // (e.g. only task.md.metadata.json exists, yielding start==end).
+  // Include both resolved snapshots and current task.md so entries with a
+  // single resolved snapshot can still compute a span against the current file.
   if (durationMinutes === 0) {
-    const resolvedMtimes = [];
+    const artifactMtimes = [];
     for (const f of allFiles) {
-      if (!/\.resolved\.\d+$/.test(f)) continue;
-      try { resolvedMtimes.push(fs.statSync(path.join(dirPath, f)).mtimeMs); } catch {}
+      if (/\.resolved\.\d+$/.test(f) || f === 'task.md') {
+        try { artifactMtimes.push(fs.statSync(path.join(dirPath, f)).mtimeMs); } catch {}
+      }
     }
-    if (resolvedMtimes.length >= 2) {
-      const span = Math.max(...resolvedMtimes) - Math.min(...resolvedMtimes);
+    if (artifactMtimes.length >= 2) {
+      const span = Math.max(...artifactMtimes) - Math.min(...artifactMtimes);
       if (span > 0) durationMinutes = Math.round(span / 60000);
     }
   }

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -306,19 +306,18 @@ function extractMetaGemini(dirPath) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
 
-  // Use distinct metadata timestamps as the user turn proxy.
-  // Task snapshots are unreliable — Gemini auto-creates resolved.N files
-  // on checklist updates even without user interaction. Distinct metadata
-  // timestamps better reflect actual user-initiated sessions.
-  const metaTimestamps = new Set();
-  for (const f of allFiles) {
-    if (!f.endsWith('.metadata.json')) continue;
-    try {
-      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, f), 'utf-8'));
-      if (meta.updatedAt) metaTimestamps.add(meta.updatedAt);
-    } catch {}
-  }
-  const userMessageCount = Math.max(metaTimestamps.size, 1);
+  // Count user turns from task.md resolved snapshots only.
+  // Other artifacts (plan, walkthrough) have their own .metadata.json but
+  // those track agent-generated updates, not user interactions. Each
+  // task.md.resolved.N represents a distinct user-initiated task revision.
+  // The current task.md counts as the initial turn.
+  const taskResolved = allFiles.filter(
+    (f) => /^task\.md\.resolved\.\d+$/.test(f)
+  ).length;
+  // For entries with no resolved snapshots, we only have the initial task —
+  // that's 1 user turn. With resolved snapshots, each snapshot is a prior
+  // revision plus the current task.md.
+  const userMessageCount = taskResolved > 0 ? taskResolved + 1 : 1;
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -306,18 +306,25 @@ function extractMetaGemini(dirPath) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
 
-  // Count user turns from task.md resolved snapshots only.
-  // Other artifacts (plan, walkthrough) have their own .metadata.json but
-  // those track agent-generated updates, not user interactions. Each
-  // task.md.resolved.N represents a distinct user-initiated task revision.
-  // The current task.md counts as the initial turn.
-  const taskResolved = allFiles.filter(
-    (f) => /^task\.md\.resolved\.\d+$/.test(f)
-  ).length;
-  // For entries with no resolved snapshots, we only have the initial task —
-  // that's 1 user turn. With resolved snapshots, each snapshot is a prior
-  // revision plus the current task.md.
-  const userMessageCount = taskResolved > 0 ? taskResolved + 1 : 1;
+  // Gemini brain entries don't reliably distinguish user-initiated turns
+  // from agent-generated artifact updates. Count distinct metadata
+  // timestamps separated by >60s as separate interactions — timestamps
+  // within the same minute are assumed to be from a single agent run.
+  const allMetaTimestamps = [];
+  for (const f of allFiles) {
+    if (!f.endsWith('.metadata.json')) continue;
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, f), 'utf-8'));
+      if (meta.updatedAt) allMetaTimestamps.push(new Date(meta.updatedAt).getTime());
+    } catch {}
+  }
+  allMetaTimestamps.sort((a, b) => a - b);
+  let userMessageCount = allMetaTimestamps.length > 0 ? 1 : 0;
+  for (let i = 1; i < allMetaTimestamps.length; i++) {
+    if (allMetaTimestamps[i] - allMetaTimestamps[i - 1] > 60000) {
+      userMessageCount++;
+    }
+  }
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;
@@ -364,20 +371,10 @@ function extractMetaGemini(dirPath) {
           } catch {}
         }
         // If the linked directory no longer exists (e.g. deleted worktree),
-        // use the deepest recognizable project-like path segment to avoid
-        // splitting one repo into per-subdirectory projects.
-        if (!cwd) {
-          const parts2 = filePath.split('/');
-          // Use the last directory component that looks like a project name
-          // (before src/, lib/, etc.) or fall back to the parent directory.
-          for (let j = parts2.length - 2; j >= 1; j--) {
-            if (['src', 'lib', 'pkg', 'cmd', 'internal', 'components', 'app'].includes(parts2[j])) {
-              cwd = parts2.slice(0, j).join('/');
-              break;
-            }
-          }
-          if (!cwd) cwd = path.dirname(filePath);
-        }
+        // use the raw file path as-is. The gemini/<uuid> fallback in scan()
+        // will handle grouping for link-less entries. Using path.dirname
+        // here would split one repo across subdirectories.
+        if (!cwd) cwd = filePath;
       }
     } catch {}
   }

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -306,13 +306,13 @@ function extractMetaGemini(dirPath) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
 
-  // Count resolved snapshots as a proxy for user interactions.
-  // Only resolved files indicate real iterative work — the base .md files
-  // (task, plan, walkthrough) are often auto-generated in a single shot.
-  const resolvedFiles = allFiles.filter(
-    (f) => /\.resolved\.\d+$/.test(f)
-  );
-  const userMessageCount = resolvedFiles.length;
+  // Count only task.md resolved snapshots as user turns.
+  // Plan/walkthrough snapshots are AI-generated artifacts — counting them
+  // would let one-shot entries (with task+plan+walkthrough resolved.0) pass
+  // the MIN_USER_MESSAGES filter.
+  const userMessageCount = allFiles.filter(
+    (f) => /^task\.md\.resolved\.\d+$/.test(f)
+  ).length;
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;
@@ -368,6 +368,20 @@ function extractMetaGemini(dirPath) {
     const dt = new Date(endTimestamp).getTime() - new Date(startTimestamp).getTime();
     if (!Number.isNaN(dt) && dt > 0) {
       durationMinutes = Math.round(dt / 60000);
+    }
+  }
+
+  // Fallback: derive duration from resolved snapshot mtimes when metadata
+  // is singular (e.g. only task.md.metadata.json exists, yielding start==end)
+  if (durationMinutes === 0) {
+    const resolvedMtimes = [];
+    for (const f of allFiles) {
+      if (!/\.resolved\.\d+$/.test(f)) continue;
+      try { resolvedMtimes.push(fs.statSync(path.join(dirPath, f)).mtimeMs); } catch {}
+    }
+    if (resolvedMtimes.length >= 2) {
+      const span = Math.max(...resolvedMtimes) - Math.min(...resolvedMtimes);
+      if (span > 0) durationMinutes = Math.round(span / 60000);
     }
   }
 

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -306,15 +306,19 @@ function extractMetaGemini(dirPath) {
     try { totalSize += fs.statSync(path.join(dirPath, f)).size; } catch {}
   }
 
-  // Count task.md resolved snapshots + the current task.md as user turns.
-  // Plan/walkthrough snapshots are AI-generated artifacts — counting them
-  // would let one-shot entries (with task+plan+walkthrough resolved.0) pass
-  // the MIN_USER_MESSAGES filter. The current task.md counts as one turn
-  // since formatGeminiSession() emits it alongside resolved snapshots.
-  const taskResolvedCount = allFiles.filter(
-    (f) => /^task\.md\.resolved\.\d+$/.test(f)
-  ).length;
-  const userMessageCount = taskResolvedCount + 1;
+  // Use distinct metadata timestamps as the user turn proxy.
+  // Task snapshots are unreliable — Gemini auto-creates resolved.N files
+  // on checklist updates even without user interaction. Distinct metadata
+  // timestamps better reflect actual user-initiated sessions.
+  const metaTimestamps = new Set();
+  for (const f of allFiles) {
+    if (!f.endsWith('.metadata.json')) continue;
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(dirPath, f), 'utf-8'));
+      if (meta.updatedAt) metaTimestamps.add(meta.updatedAt);
+    } catch {}
+  }
+  const userMessageCount = Math.max(metaTimestamps.size, 1);
 
   // Extract timestamps from metadata sidecars
   let startTimestamp = null;
@@ -360,7 +364,21 @@ function extractMetaGemini(dirPath) {
             }
           } catch {}
         }
-        if (!cwd) cwd = path.dirname(filePath);
+        // If the linked directory no longer exists (e.g. deleted worktree),
+        // use the deepest recognizable project-like path segment to avoid
+        // splitting one repo into per-subdirectory projects.
+        if (!cwd) {
+          const parts2 = filePath.split('/');
+          // Use the last directory component that looks like a project name
+          // (before src/, lib/, etc.) or fall back to the parent directory.
+          for (let j = parts2.length - 2; j >= 1; j--) {
+            if (['src', 'lib', 'pkg', 'cmd', 'internal', 'components', 'app'].includes(parts2[j])) {
+              cwd = parts2.slice(0, j).join('/');
+              break;
+            }
+          }
+          if (!cwd) cwd = path.dirname(filePath);
+        }
       }
     } catch {}
   }
@@ -373,11 +391,12 @@ function extractMetaGemini(dirPath) {
     }
   }
 
-  // Fallback: derive duration from artifact mtimes when metadata is singular
-  // (e.g. only task.md.metadata.json exists, yielding start==end).
-  // Include both resolved snapshots and current task.md so entries with a
-  // single resolved snapshot can still compute a span against the current file.
-  if (durationMinutes === 0) {
+  // Fallback: derive duration from artifact mtimes ONLY when metadata has
+  // no usable span (start==end or missing). Do not fall back when metadata
+  // yields a real sub-minute span (rounded to 0), as old resolved snapshots
+  // can be days older and would inflate the duration.
+  const hasMetadataSpan = startTimestamp && endTimestamp && startTimestamp !== endTimestamp;
+  if (durationMinutes === 0 && !hasMetadataSpan) {
     const artifactMtimes = [];
     for (const f of allFiles) {
       if (/\.resolved\.\d+$/.test(f) || f === 'task.md') {

--- a/researchskills-extract/scripts/scan-sessions.js
+++ b/researchskills-extract/scripts/scan-sessions.js
@@ -371,10 +371,8 @@ function extractMetaGemini(dirPath) {
           } catch {}
         }
         // If the linked directory no longer exists (e.g. deleted worktree),
-        // use the raw file path as-is. The gemini/<uuid> fallback in scan()
-        // will handle grouping for link-less entries. Using path.dirname
-        // here would split one repo across subdirectories.
-        if (!cwd) cwd = filePath;
+        // leave cwd unset. scan() will fall back to gemini/<uuid> which
+        // avoids splitting one repo across file-level pseudo-projects.
       }
     } catch {}
   }


### PR DESCRIPTION
## Summary

- Rebases #68 onto main after the `extract-knowhow` → `researchskills-extract` rename
- Adds Gemini CLI brain entries (`~/.gemini/antigravity/brain/<uuid>/`) as a third session source alongside Claude Code and Codex
- Brain entries use markdown artifacts (task.md, implementation_plan.md, walkthrough.md) with metadata sidecars and `.resolved.N` historical snapshots instead of JSONL
- `scan-sessions.js`: `discoverGemini()` finds UUID dirs with task.md, `extractMetaGemini()` parses metadata from sidecars and `file://` links
- `format-session.js`: `formatGeminiSession()` reconstructs a session narrative from the markdown artifacts, with snapshots sorted chronologically by mtime

### Codex review findings addressed (7 rounds):
- P1: Derive duration from snapshot mtimes when metadata is singular
- P1: Stop attributing task.md to USER (labeled as CONTEXT)
- P1: Leave cwd unset for deleted worktrees (fall back to gemini/<uuid>)
- P2: Cap assistant artifacts to ASSISTANT_MAX_CHARS (80)
- P2: Debounce metadata timestamps by 60s for turn counting
- P2: Sort metadata summaries by updatedAt for deterministic output
- P3: Preserve chronology (snapshots before current artifacts)

Closes #28 (partial — addresses the Gemini brain integration path; broader IDE/schema discussions remain open)
Supersedes #68

## Test plan

- [ ] Run `node researchskills-extract/scripts/scan-sessions.js` and verify Gemini sessions appear in work list
- [ ] Run `node researchskills-extract/scripts/format-session.js <gemini-brain-dir> /tmp/test.txt` and verify output
- [ ] Verify one-shot entries (no resolved snapshots) are filtered out by MIN_USER_MESSAGES
- [ ] Verify deleted-worktree entries get gemini/<uuid> project paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)