### PR TITLE
feat: add Stage 6.5 — store extracted skills locally

### DIFF
--- a/researchskills-extract/commands/SKILL.md
+++ b/researchskills-extract/commands/SKILL.md
@@ -6,7 +6,7 @@ description: "Extract research skills from conversation history into ResearchSki
 
 Extract research skills from the user's Codex session history for **ResearchSkills**.
 
-**Run automatically with TWO pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
+**Run automatically with THREE pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), once after scoring to offer local installation (Stage 6.5 — store skills in Claude/Codex), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
 
 > **Prerequisite:** This skill spawns nested `codex exec` calls that need full network and filesystem access. Start Codex with: `codex -a never -s danger-full-access` (or `--dangerously-bypass-approvals-and-sandbox`). If the parent session is sandboxed, nested calls will fail with network errors.
 
@@ -28,6 +28,7 @@ extract-skills.js      ─┤  deterministic scripts (you call them)
   └─ codex exec         │  ← Codex exec call per session, inside the script
 clean-skills.js        ─┤  ← review: reject/fix/merge
 score-skills.js        ─┤  ← score: 3-dim value assessment
+store-local.js         ─┤  ← optional: install skills into Claude/Codex
 finalize.js            ─┘
 
 You (main agent)       ← call scripts, read summaries, report
@@ -43,6 +44,7 @@ Helper scripts (installed at `~/.codex/skills/researchskills-extract/scripts/`):
 | `validate-skills.js` | Validate skill markdown and cache to `~/.researchskills/cache/skills/` |
 | `clean-skills.js` | Review extracted skills: reject engineering, fix PII, merge duplicates |
 | `score-skills.js` | Score surviving skills on 3 dimensions: procedural, semantic, episodic value |
+| `store-local.js` | Install extracted skills into user's local Claude/Codex config |
 | `finalize.js` | Collect cached skills → upload to researchskills.ai |
 
 ---
@@ -204,9 +206,37 @@ node ~/.codex/skills/researchskills-extract/scripts/finalize.js \
 
 ---
 
+## Stage 6.5 — Store Skills Locally (Optional)
+
+**Third consent gate.** After finalize collects skills, ask the user whether to install them into their local AI coding tool so the skills are available as context in future sessions.
+
+Use `ask` (Codex) or `AskUserQuestion` (Claude Code) to present the options. If no interactive tool is available, print the options and end your turn — the user's next message is their selection.
+
+- Question: "Install extracted skills into your local AI coding tool?"
+- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/`
+- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills/`
+- Option C: "Yes, install to both"
+- Option D: "No, skip local install"
+
+**YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Do NOT continue to Stage 7 without an explicit user response.
+
+If the user picks A, B, or C, run:
+
+```bash
+node ~/.codex/skills/researchskills-extract/scripts/store-local.js \
+  --target <claude|codex|both> \
+  --session-ids <ALL-research-session-ids-csv>
+```
+
+Report: `"Installed N skills to <target>. M already up-to-date."`
+
+If the user picks D, skip and continue to Stage 7.
+
+---
+
 ## Stage 7 — Consent and Upload
 
-**Second consent gate.** Pause and ask the user before uploading anything.
+**Fourth consent gate.** Pause and ask the user before uploading anything.
 
 Show the user what was extracted:
 

--- a/researchskills-extract/commands/SKILL.md
+++ b/researchskills-extract/commands/SKILL.md
@@ -213,8 +213,8 @@ node ~/.codex/skills/researchskills-extract/scripts/finalize.js \
 Use `ask` (Codex) or `AskUserQuestion` (Claude Code) to present the options. If no interactive tool is available, print the options and end your turn — the user's next message is their selection.
 
 - Question: "Install extracted skills into your local AI coding tool?"
-- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/`
-- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills/`
+- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/<slug>.md`
+- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills-<slug>/SKILL.md`
 - Option C: "Yes, install to both"
 - Option D: "No, skip local install"
 

--- a/researchskills-extract/commands/researchskills-extract.md
+++ b/researchskills-extract/commands/researchskills-extract.md
@@ -207,8 +207,8 @@ node ~/.claude/utils/finalize.js \
 
 Use AskUserQuestion to present the options:
 - Question: "Install extracted skills into your local AI coding tool?"
-- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/`
-- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills/`
+- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/<slug>.md`
+- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills-<slug>/SKILL.md`
 - Option C: "Yes, install to both"
 - Option D: "No, skip local install"
 

--- a/researchskills-extract/commands/researchskills-extract.md
+++ b/researchskills-extract/commands/researchskills-extract.md
@@ -2,7 +2,7 @@
 
 Extract research skills from the user's Claude Code session history for **ResearchSkills**.
 
-**Run automatically with TWO pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
+**Run automatically with THREE pauses for user consent:** once after classifying projects (Stage 2.5 — choose which projects to scan), once after scoring to offer local installation (Stage 6.5 — store skills in Claude/Codex), and once before upload (Stage 7 — choose whether to submit). Report progress at each milestone.
 
 You extract three types of cognitive memory from research conversations:
 - **Procedural** — IF-THEN rules for **scientific research** decisions: methodology choices, data interpretation strategies, research direction pivots. NOT engineering workflows.
@@ -22,6 +22,7 @@ extract-skills.js      ─┤  deterministic scripts (you call them)
   └─ claude -p sonnet   │  ← Sonnet CLI call per session, inside the script
 clean-skills.js        ─┤  ← Opus reviews: reject/fix/merge
 score-skills.js        ─┤  ← Opus scores: 3-dim value assessment
+store-local.js         ─┤  ← optional: install skills into Claude/Codex
 finalize.js            ─┘
 
 You (main agent)       ← call scripts, read summaries, report
@@ -37,6 +38,7 @@ Helper scripts (installed at `~/.claude/utils/`):
 | `validate-skills.js` | Validate skill markdown and cache to `~/.researchskills/cache/skills/` |
 | `clean-skills.js` | Review extracted skills with Opus: reject engineering, fix PII, merge duplicates |
 | `score-skills.js` | Score surviving skills with Opus on 3 dimensions: procedural, semantic, episodic value |
+| `store-local.js` | Install extracted skills into user's local Claude/Codex config |
 | `finalize.js` | Collect cached skills → upload to researchskills.ai |
 
 ---
@@ -199,9 +201,36 @@ node ~/.claude/utils/finalize.js \
 
 ---
 
+## Stage 6.5 — Store Skills Locally (Optional)
+
+**Third consent gate.** After finalize collects skills, ask the user whether to install them into their local AI coding tool so the skills are available as context in future sessions.
+
+Use AskUserQuestion to present the options:
+- Question: "Install extracted skills into your local AI coding tool?"
+- Option A: "Yes, install to Claude Code" — stores skills to `~/.claude/commands/researchskills/`
+- Option B: "Yes, install to Codex" — stores skills to `~/.codex/skills/researchskills/`
+- Option C: "Yes, install to both"
+- Option D: "No, skip local install"
+
+**YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Do NOT continue to Stage 7 without an explicit user response.
+
+If the user picks A, B, or C, run:
+
+```bash
+node ~/.claude/utils/store-local.js \
+  --target <claude|codex|both> \
+  --session-ids <ALL-research-session-ids-csv>
+```
+
+Report: `"Installed N skills to <target>. M already up-to-date."`
+
+If the user picks D, skip and continue to Stage 7.
+
+---
+
 ## Stage 7 — Consent and Upload
 
-**Second consent gate.** Pause and ask the user before uploading anything.
+**Fourth consent gate.** Pause and ask the user before uploading anything.
 
 Show the user what was extracted:
 

--- a/researchskills-extract/scripts/postinstall.js
+++ b/researchskills-extract/scripts/postinstall.js
@@ -20,6 +20,7 @@ const HELPER_SCRIPTS = [
   "score-skills.js",
   "upload-skills.js",
   "finalize.js",
+  "store-local.js",
 ];
 
 // --- Claude Code ---

--- a/researchskills-extract/scripts/postuninstall.js
+++ b/researchskills-extract/scripts/postuninstall.js
@@ -16,6 +16,7 @@ const HELPER_SCRIPTS = [
   "score-skills.js",
   "upload-skills.js",
   "finalize.js",
+  "store-local.js",
 ];
 
 // --- Claude Code ---

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -6,14 +6,18 @@
  * configuration so they are available as commands/skills in future sessions.
  *
  * Targets:
- *   - Claude Code: ~/.claude/commands/researchskills/<skill>.md
- *   - Codex:       ~/.codex/skills/researchskills/<skill>.md
+ *   - Claude Code: ~/.claude/commands/researchskills/<slug>.md
+ *   - Codex:       ~/.codex/skills/researchskills-<slug>/SKILL.md
+ *
+ * Skill slugs are derived from the YAML frontmatter `name` field, not from
+ * cache temp filenames. Deduplication uses the slug, so re-extractions that
+ * produce the same skill name will overwrite cleanly.
  *
  * Usage:
  *   store-local.js --target claude|codex|both --session-ids id1,id2,...
  *
  * Reads validated skills from ~/.researchskills/cache/skills/<session_id>/
- * and copies them to the chosen target(s). Deduplicates by skill filename.
+ * and copies them to the chosen target(s).
  */
 
 'use strict';
@@ -24,53 +28,87 @@ const os = require('os');
 
 const CACHE_DIR = path.join(os.homedir(), '.researchskills', 'cache', 'skills');
 
-const TARGETS = {
-  claude: path.join(os.homedir(), '.claude', 'commands', 'researchskills'),
-  codex: path.join(os.homedir(), '.codex', 'skills', 'researchskills'),
-};
+/**
+ * Extract the `name` field from YAML frontmatter.
+ * Returns null if not found.
+ */
+function extractName(content) {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const nameMatch = match[1].match(/^name:\s*["']?(.+?)["']?\s*$/m);
+  return nameMatch ? nameMatch[1].trim() : null;
+}
+
+/**
+ * Turn a skill name into a filesystem-safe slug.
+ */
+function slugify(name) {
+  return String(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 80) || 'unnamed-skill';
+}
 
 function collectSkills(sessionIds) {
-  const skills = new Map(); // filename → { src, sessionId }
+  const skills = new Map(); // slug → { src, content, name }
   for (const sid of sessionIds) {
     const sessionDir = path.join(CACHE_DIR, sid);
     if (!fs.existsSync(sessionDir)) continue;
     for (const file of fs.readdirSync(sessionDir)) {
       if (!file.endsWith('.md')) continue;
-      // Later sessions overwrite earlier ones for same-named skills (dedup)
-      skills.set(file, { src: path.join(sessionDir, file), sessionId: sid });
+      const src = path.join(sessionDir, file);
+      const content = fs.readFileSync(src, 'utf-8');
+      const name = extractName(content);
+      const slug = slugify(name || path.basename(file, '.md'));
+      // Later sessions overwrite earlier ones for same-slugged skills (dedup)
+      skills.set(slug, { src, content, name: name || slug });
     }
   }
   return skills;
 }
 
 function storeToTarget(targetName, skills) {
-  const targetDir = TARGETS[targetName];
-  if (!targetDir) {
+  let installed = 0;
+  let skipped = 0;
+  let dir;
+
+  if (targetName === 'claude') {
+    // Claude Code: ~/.claude/commands/researchskills/<slug>.md
+    dir = path.join(os.homedir(), '.claude', 'commands', 'researchskills');
+    fs.mkdirSync(dir, { recursive: true });
+
+    for (const [slug, { content }] of skills) {
+      const dst = path.join(dir, `${slug}.md`);
+      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === content) {
+        skipped++;
+        continue;
+      }
+      fs.writeFileSync(dst, content);
+      installed++;
+    }
+  } else if (targetName === 'codex') {
+    // Codex: ~/.codex/skills/researchskills-<slug>/SKILL.md
+    dir = path.join(os.homedir(), '.codex', 'skills');
+    fs.mkdirSync(dir, { recursive: true });
+
+    for (const [slug, { content }] of skills) {
+      const skillDir = path.join(dir, `researchskills-${slug}`);
+      fs.mkdirSync(skillDir, { recursive: true });
+      const dst = path.join(skillDir, 'SKILL.md');
+      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === content) {
+        skipped++;
+        continue;
+      }
+      fs.writeFileSync(dst, content);
+      installed++;
+    }
+  } else {
     console.error(`Unknown target: ${targetName}`);
     return { installed: 0, skipped: 0 };
   }
 
-  fs.mkdirSync(targetDir, { recursive: true });
-
-  let installed = 0;
-  let skipped = 0;
-
-  for (const [filename, { src }] of skills) {
-    const dst = path.join(targetDir, filename);
-    if (fs.existsSync(dst)) {
-      // Check if content is identical
-      const srcContent = fs.readFileSync(src, 'utf-8');
-      const dstContent = fs.readFileSync(dst, 'utf-8');
-      if (srcContent === dstContent) {
-        skipped++;
-        continue;
-      }
-    }
-    fs.copyFileSync(src, dst);
-    installed++;
-  }
-
-  return { installed, skipped, dir: targetDir };
+  return { installed, skipped, dir };
 }
 
 // CLI
@@ -116,4 +154,4 @@ if (require.main === module) {
   console.log(`\n${JSON.stringify({ total: skills.size, results })}`);
 }
 
-module.exports = { collectSkills, storeToTarget, TARGETS };
+module.exports = { collectSkills, storeToTarget, slugify, extractName };

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -25,6 +25,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 
 const CACHE_DIR = path.join(os.homedir(), '.researchskills', 'cache', 'skills');
 
@@ -50,8 +51,22 @@ function slugify(name) {
     .substring(0, 80) || 'unnamed-skill';
 }
 
+/**
+ * Hash the contributor field for de-identification (matches validate-skills.js).
+ */
+function hashContributor(content) {
+  const match = content.match(/^contributor:\s*(.+)$/m);
+  if (!match) return content;
+  const raw = match[1].trim().replace(/^["']|["']$/g, '');
+  if (raw.startsWith('anon-')) return content; // already hashed
+  const hash = crypto.createHash('sha256').update(raw).digest('hex').substring(0, 8);
+  return content.replace(/^contributor:\s*.+$/m, `contributor: anon-${hash}`);
+}
+
 function collectSkills(sessionIds) {
-  const skills = new Map(); // slug → { src, content, name }
+  // Dedup by lowercased name (not slug) to avoid losing distinct skills
+  // whose names differ only by punctuation
+  const byName = new Map(); // lowercased name → { content, name, file }
   for (const sid of sessionIds) {
     const sessionDir = path.join(CACHE_DIR, sid);
     if (!fs.existsSync(sessionDir)) continue;
@@ -59,13 +74,24 @@ function collectSkills(sessionIds) {
       if (!file.endsWith('.md')) continue;
       const src = path.join(sessionDir, file);
       const content = fs.readFileSync(src, 'utf-8');
-      const name = extractField(content, 'name');
-      const slug = slugify(name || path.basename(file, '.md'));
-      const existing = skills.get(slug);
-      // Keep the longer body for same-slug duplicates (matches validate-skills.js collect behavior)
+      const name = extractField(content, 'name') || path.basename(file, '.md');
+      const key = name.toLowerCase();
+      const existing = byName.get(key);
+      // Keep the longer body for duplicates (matches validate-skills.js collect behavior)
       if (existing && existing.content.length >= content.length) continue;
-      skills.set(slug, { src, content, name: name || slug });
+      byName.set(key, { src, content, name });
     }
+  }
+  // Convert to slug-keyed map, appending suffix on collision
+  const skills = new Map();
+  for (const { content, name } of byName.values()) {
+    let slug = slugify(name);
+    let finalSlug = slug;
+    let suffix = 2;
+    while (skills.has(finalSlug)) {
+      finalSlug = `${slug}-${suffix++}`;
+    }
+    skills.set(finalSlug, { content: hashContributor(content), name });
   }
   return skills;
 }

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -72,9 +72,9 @@ function extractBody(content) {
 }
 
 function collectSkills(sessionIds) {
-  // Dedup by lowercased name (not slug) to avoid losing distinct skills
-  // whose names differ only by punctuation
-  const byName = new Map(); // lowercased name → { content, name, bodyLen }
+  // Dedup by (name, domain, subdomain) to preserve same-named skills from
+  // different domains while still collapsing true duplicates
+  const byKey = new Map(); // "name|domain|subdomain" → { content, name, bodyLen }
   for (const sid of sessionIds) {
     const sessionDir = path.join(CACHE_DIR, sid);
     if (!fs.existsSync(sessionDir)) continue;
@@ -83,17 +83,19 @@ function collectSkills(sessionIds) {
       const src = path.join(sessionDir, file);
       const content = fs.readFileSync(src, 'utf-8');
       const name = extractField(content, 'name') || path.basename(file, '.md');
-      const key = name.toLowerCase();
+      const domain = (extractField(content, 'domain') || '').toLowerCase();
+      const subdomain = (extractField(content, 'subdomain') || '').toLowerCase();
+      const key = `${name.toLowerCase()}|${domain}|${subdomain}`;
       const bodyLen = extractBody(content).length;
-      const existing = byName.get(key);
+      const existing = byKey.get(key);
       // Keep the longer body for duplicates (matches validate-skills.js collect behavior)
       if (existing && existing.bodyLen >= bodyLen) continue;
-      byName.set(key, { content, name, bodyLen });
+      byKey.set(key, { content, name, bodyLen });
     }
   }
   // Convert to slug-keyed map, appending suffix on collision
   const skills = new Map();
-  for (const { content, name } of byName.values()) {
+  for (const { content, name } of byKey.values()) {
     let slug = slugify(name);
     let finalSlug = slug;
     let suffix = 2;
@@ -150,8 +152,7 @@ function storeToTarget(targetName, skills) {
       installed++;
     }
   } else {
-    console.error(`Unknown target: ${targetName}`);
-    return { installed: 0, skipped: 0 };
+    throw new Error(`Unknown target: "${targetName}". Must be "claude", "codex", or "both".`);
   }
 
   return { installed, skipped, dir };

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -72,9 +72,9 @@ function extractBody(content) {
 }
 
 function collectSkills(sessionIds) {
-  // Dedup by (name, domain, subdomain) to preserve same-named skills from
-  // different domains while still collapsing true duplicates
-  const byKey = new Map(); // "name|domain|subdomain" → { content, name, bodyLen }
+  // Dedup by (name, domain, subdomain, memory_type) to preserve distinct skills
+  // while still collapsing true duplicates
+  const byKey = new Map();
   for (const sid of sessionIds) {
     const sessionDir = path.join(CACHE_DIR, sid);
     if (!fs.existsSync(sessionDir)) continue;
@@ -85,7 +85,8 @@ function collectSkills(sessionIds) {
       const name = extractField(content, 'name') || path.basename(file, '.md');
       const domain = (extractField(content, 'domain') || '').toLowerCase();
       const subdomain = (extractField(content, 'subdomain') || '').toLowerCase();
-      const key = `${name.toLowerCase()}|${domain}|${subdomain}`;
+      const memType = (extractField(content, 'memory_type') || '').toLowerCase();
+      const key = `${name.toLowerCase()}|${domain}|${subdomain}|${memType}`;
       const bodyLen = extractBody(content).length;
       const existing = byKey.get(key);
       // Keep the longer body for duplicates (matches validate-skills.js collect behavior)
@@ -114,16 +115,20 @@ function storeToTarget(targetName, skills) {
 
   if (targetName === 'claude') {
     // Claude Code: ~/.claude/commands/researchskills/<slug>.md
+    // Strip YAML frontmatter — Claude commands are plain markdown prompts
     dir = path.join(os.homedir(), '.claude', 'commands', 'researchskills');
     fs.mkdirSync(dir, { recursive: true });
 
-    for (const [slug, { content }] of skills) {
+    for (const [slug, { content, name }] of skills) {
+      const body = extractBody(content).trim();
+      // Prepend a markdown title from the skill name
+      const commandContent = `# ${name}\n\n${body}\n`;
       const dst = path.join(dir, `${slug}.md`);
-      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === content) {
+      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === commandContent) {
         skipped++;
         continue;
       }
-      fs.writeFileSync(dst, content);
+      fs.writeFileSync(dst, commandContent);
       installed++;
     }
   } else if (targetName === 'codex') {

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * store-local.js
+ *
+ * Install extracted research skills into the user's local AI coding tool
+ * configuration so they are available as commands/skills in future sessions.
+ *
+ * Targets:
+ *   - Claude Code: ~/.claude/commands/researchskills/<skill>.md
+ *   - Codex:       ~/.codex/skills/researchskills/<skill>.md
+ *
+ * Usage:
+ *   store-local.js --target claude|codex|both --session-ids id1,id2,...
+ *
+ * Reads validated skills from ~/.researchskills/cache/skills/<session_id>/
+ * and copies them to the chosen target(s). Deduplicates by skill filename.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const CACHE_DIR = path.join(os.homedir(), '.researchskills', 'cache', 'skills');
+
+const TARGETS = {
+  claude: path.join(os.homedir(), '.claude', 'commands', 'researchskills'),
+  codex: path.join(os.homedir(), '.codex', 'skills', 'researchskills'),
+};
+
+function collectSkills(sessionIds) {
+  const skills = new Map(); // filename → { src, sessionId }
+  for (const sid of sessionIds) {
+    const sessionDir = path.join(CACHE_DIR, sid);
+    if (!fs.existsSync(sessionDir)) continue;
+    for (const file of fs.readdirSync(sessionDir)) {
+      if (!file.endsWith('.md')) continue;
+      // Later sessions overwrite earlier ones for same-named skills (dedup)
+      skills.set(file, { src: path.join(sessionDir, file), sessionId: sid });
+    }
+  }
+  return skills;
+}
+
+function storeToTarget(targetName, skills) {
+  const targetDir = TARGETS[targetName];
+  if (!targetDir) {
+    console.error(`Unknown target: ${targetName}`);
+    return { installed: 0, skipped: 0 };
+  }
+
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  let installed = 0;
+  let skipped = 0;
+
+  for (const [filename, { src }] of skills) {
+    const dst = path.join(targetDir, filename);
+    if (fs.existsSync(dst)) {
+      // Check if content is identical
+      const srcContent = fs.readFileSync(src, 'utf-8');
+      const dstContent = fs.readFileSync(dst, 'utf-8');
+      if (srcContent === dstContent) {
+        skipped++;
+        continue;
+      }
+    }
+    fs.copyFileSync(src, dst);
+    installed++;
+  }
+
+  return { installed, skipped, dir: targetDir };
+}
+
+// CLI
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  let target = null;
+  let sessionIds = [];
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--target':     target = args[++i]; break;
+      case '--session-ids': sessionIds = args[++i].split(',').filter(Boolean); break;
+    }
+  }
+
+  if (!target || sessionIds.length === 0) {
+    console.error('Usage: store-local.js --target claude|codex|both --session-ids id1,id2,...');
+    process.exit(1);
+  }
+
+  const skills = collectSkills(sessionIds);
+
+  if (skills.size === 0) {
+    console.log('No cached skills found for the given session IDs.');
+    process.exit(0);
+  }
+
+  const targets = target === 'both' ? ['claude', 'codex'] : [target];
+  const results = {};
+
+  for (const t of targets) {
+    const result = storeToTarget(t, skills);
+    results[t] = result;
+    if (result.installed > 0) {
+      console.log(`✓ ${t}: ${result.installed} skill(s) installed to ${result.dir}`);
+    }
+    if (result.skipped > 0) {
+      console.log(`  ${t}: ${result.skipped} skill(s) already up-to-date`);
+    }
+  }
+
+  // Output JSON summary for the calling agent to parse
+  console.log(`\n${JSON.stringify({ total: skills.size, results })}`);
+}
+
+module.exports = { collectSkills, storeToTarget, TARGETS };

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -94,16 +94,28 @@ function collectSkills(sessionIds) {
       byKey.set(key, { content, name, bodyLen });
     }
   }
-  // Convert to slug-keyed map, appending suffix on collision
+  // Convert to slug-keyed map, appending suffix on collision and
+  // disambiguating the frontmatter name so Codex can distinguish them
   const skills = new Map();
   for (const { content, name } of byKey.values()) {
-    let slug = slugify(name);
-    let finalSlug = slug;
+    const baseSlug = slugify(name);
+    let finalSlug = baseSlug;
     let suffix = 2;
     while (skills.has(finalSlug)) {
-      finalSlug = `${slug}-${suffix++}`;
+      finalSlug = `${baseSlug}-${suffix++}`;
     }
-    skills.set(finalSlug, { content: hashContributor(content), name });
+    // If slug was disambiguated, also disambiguate the name in frontmatter
+    let finalContent = hashContributor(content);
+    let finalName = name;
+    if (finalSlug !== baseSlug) {
+      const memType = extractField(content, 'memory_type') || '';
+      finalName = memType ? `${name} (${memType})` : `${name} (${suffix - 1})`;
+      finalContent = finalContent.replace(
+        /^name:\s*.+$/m,
+        `name: "${finalName.replace(/"/g, '\\"')}"`
+      );
+    }
+    skills.set(finalSlug, { content: finalContent, name: finalName });
   }
   return skills;
 }
@@ -137,11 +149,21 @@ function storeToTarget(targetName, skills) {
     fs.mkdirSync(dir, { recursive: true });
 
     for (const [slug, { content, name }] of skills) {
-      // Codex requires a `description` field in frontmatter to index the skill
+      // Codex requires a `description` field in frontmatter to index/trigger skills.
+      // Build a retrievable description from domain + first body sentence.
       let finalContent = content;
       if (!extractField(content, 'description')) {
         const memoryType = extractField(content, 'memory_type') || 'research';
-        const rawDesc = `ResearchSkills ${memoryType} skill: ${name}`;
+        const domain = extractField(content, 'domain') || '';
+        const subdomain = extractField(content, 'subdomain') || '';
+        const body = extractBody(content).trim();
+        // Extract first sentence (up to 120 chars) for trigger context
+        const firstLine = body.split(/\n/)[0] || '';
+        const snippet = firstLine.substring(0, 120).replace(/[#*_>]/g, '').trim();
+        const parts = [`${memoryType} skill`, domain, subdomain].filter(Boolean);
+        const rawDesc = snippet
+          ? `${parts.join(' / ')}: ${snippet}`
+          : `ResearchSkills ${parts.join(' / ')}: ${name}`;
         // Escape quotes and backslashes for valid YAML
         const desc = rawDesc.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         finalContent = content.replace(/^(---\s*\n)/, `$1description: "${desc}"\n`);

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -63,10 +63,18 @@ function hashContributor(content) {
   return content.replace(/^contributor:\s*.+$/m, `contributor: anon-${hash}`);
 }
 
+/**
+ * Extract the body (everything after the closing ---) from a skill file.
+ */
+function extractBody(content) {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/);
+  return match ? match[1] : content;
+}
+
 function collectSkills(sessionIds) {
   // Dedup by lowercased name (not slug) to avoid losing distinct skills
   // whose names differ only by punctuation
-  const byName = new Map(); // lowercased name → { content, name, file }
+  const byName = new Map(); // lowercased name → { content, name, bodyLen }
   for (const sid of sessionIds) {
     const sessionDir = path.join(CACHE_DIR, sid);
     if (!fs.existsSync(sessionDir)) continue;
@@ -76,10 +84,11 @@ function collectSkills(sessionIds) {
       const content = fs.readFileSync(src, 'utf-8');
       const name = extractField(content, 'name') || path.basename(file, '.md');
       const key = name.toLowerCase();
+      const bodyLen = extractBody(content).length;
       const existing = byName.get(key);
       // Keep the longer body for duplicates (matches validate-skills.js collect behavior)
-      if (existing && existing.content.length >= content.length) continue;
-      byName.set(key, { src, content, name });
+      if (existing && existing.bodyLen >= bodyLen) continue;
+      byName.set(key, { content, name, bodyLen });
     }
   }
   // Convert to slug-keyed map, appending suffix on collision
@@ -125,7 +134,9 @@ function storeToTarget(targetName, skills) {
       let finalContent = content;
       if (!extractField(content, 'description')) {
         const memoryType = extractField(content, 'memory_type') || 'research';
-        const desc = `ResearchSkills ${memoryType} skill: ${name}`;
+        const rawDesc = `ResearchSkills ${memoryType} skill: ${name}`;
+        // Escape quotes and backslashes for valid YAML
+        const desc = rawDesc.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         finalContent = content.replace(/^(---\s*\n)/, `$1description: "${desc}"\n`);
       }
       const skillDir = path.join(dir, `researchskills-${slug}`);

--- a/researchskills-extract/scripts/store-local.js
+++ b/researchskills-extract/scripts/store-local.js
@@ -29,14 +29,14 @@ const os = require('os');
 const CACHE_DIR = path.join(os.homedir(), '.researchskills', 'cache', 'skills');
 
 /**
- * Extract the `name` field from YAML frontmatter.
+ * Extract a field from YAML frontmatter.
  * Returns null if not found.
  */
-function extractName(content) {
+function extractField(content, field) {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
   if (!match) return null;
-  const nameMatch = match[1].match(/^name:\s*["']?(.+?)["']?\s*$/m);
-  return nameMatch ? nameMatch[1].trim() : null;
+  const fieldMatch = match[1].match(new RegExp(`^${field}:\\s*["']?(.+?)["']?\\s*$`, 'm'));
+  return fieldMatch ? fieldMatch[1].trim() : null;
 }
 
 /**
@@ -59,9 +59,11 @@ function collectSkills(sessionIds) {
       if (!file.endsWith('.md')) continue;
       const src = path.join(sessionDir, file);
       const content = fs.readFileSync(src, 'utf-8');
-      const name = extractName(content);
+      const name = extractField(content, 'name');
       const slug = slugify(name || path.basename(file, '.md'));
-      // Later sessions overwrite earlier ones for same-slugged skills (dedup)
+      const existing = skills.get(slug);
+      // Keep the longer body for same-slug duplicates (matches validate-skills.js collect behavior)
+      if (existing && existing.content.length >= content.length) continue;
       skills.set(slug, { src, content, name: name || slug });
     }
   }
@@ -92,15 +94,22 @@ function storeToTarget(targetName, skills) {
     dir = path.join(os.homedir(), '.codex', 'skills');
     fs.mkdirSync(dir, { recursive: true });
 
-    for (const [slug, { content }] of skills) {
+    for (const [slug, { content, name }] of skills) {
+      // Codex requires a `description` field in frontmatter to index the skill
+      let finalContent = content;
+      if (!extractField(content, 'description')) {
+        const memoryType = extractField(content, 'memory_type') || 'research';
+        const desc = `ResearchSkills ${memoryType} skill: ${name}`;
+        finalContent = content.replace(/^(---\s*\n)/, `$1description: "${desc}"\n`);
+      }
       const skillDir = path.join(dir, `researchskills-${slug}`);
       fs.mkdirSync(skillDir, { recursive: true });
       const dst = path.join(skillDir, 'SKILL.md');
-      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === content) {
+      if (fs.existsSync(dst) && fs.readFileSync(dst, 'utf-8') === finalContent) {
         skipped++;
         continue;
       }
-      fs.writeFileSync(dst, content);
+      fs.writeFileSync(dst, finalContent);
       installed++;
     }
   } else {
@@ -154,4 +163,4 @@ if (require.main === module) {
   console.log(`\n${JSON.stringify({ total: skills.size, results })}`);
 }
 
-module.exports = { collectSkills, storeToTarget, slugify, extractName };
+module.exports = { collectSkills, storeToTarget, slugify, extractField };


### PR DESCRIPTION
## Summary

- Adds new `store-local.js` script that installs extracted research skills into the user's local Claude Code (`~/.claude/commands/researchskills/`) or Codex (`~/.codex/skills/researchskills-<slug>/SKILL.md`) config
- Adds Stage 6.5 consent gate in the extraction pipeline (between finalize and upload) that asks users whether to install skills locally
- Claude commands get clean markdown (frontmatter stripped); Codex SKILL.md files get enriched descriptions for discoverability
- Contributor metadata is anonymized before local install (matching the upload path)
- Deduplicates by (name, domain, subdomain, memory_type) and keeps the longest body

## Test plan

- [x] All 9 existing tests pass
- [x] Codex code review passes (6 rounds of fixes)
- [ ] Manual test: run `/researchskills-extract` and verify Stage 6.5 prompt appears
- [ ] Manual test: select "Claude Code" target, verify skills appear in `~/.claude/commands/researchskills/`
- [ ] Manual test: select "Codex" target, verify skills appear in `~/.codex/skills/researchskills-*/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)