### PR TITLE
fix: default select all projects in consent gate

### DIFF
--- a/researchskills-extract/commands/SKILL.md
+++ b/researchskills-extract/commands/SKILL.md
@@ -98,17 +98,18 @@ Report: `"Classified N projects. Proceeding with M."`
 Read `~/.researchskills/cache/classification.json` and display:
 
 ```
-Select which projects to scan for research skills:
+Select which projects to scan for research skills (all selected — deselect any you want to skip):
 
   [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
   [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
-  [ ] 3. Personal Website             (3 sessions, engineering)
-  [ ] 4. Dotfiles                     (2 sessions, other)
+  [x] 3. Personal Website             (3 sessions, engineering)
+  [x] 4. Dotfiles                     (2 sessions, other)
 
+Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none
 Enter numbers to toggle, or press Enter to continue:
 ```
 
-Research projects are pre-selected; engineering/other are deselected.
+All projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
 
 **YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Use `ask` (Codex) or `AskUserQuestion` (Claude Code) to present the project list and block until the user replies. Do NOT continue to Stage 3 without an explicit user response. If no interactive tool is available, print the list and end your turn — the user's next message is their selection.
 

--- a/researchskills-extract/commands/SKILL.md
+++ b/researchskills-extract/commands/SKILL.md
@@ -105,11 +105,10 @@ Select which projects to scan for research skills (all research projects selecte
   [ ] 3. Personal Website             (3 sessions, engineering)
   [x] 4. Dotfiles                     (2 sessions, other)
 
-Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none
 Enter numbers to toggle, or press Enter to continue:
 ```
 
-All projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
+All projects are pre-selected by default. Users can deselect individual projects by number.
 
 **YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Use `ask` (Codex) or `AskUserQuestion` (Claude Code) to present the project list and block until the user replies. Do NOT continue to Stage 3 without an explicit user response. If no interactive tool is available, print the list and end your turn — the user's next message is their selection.
 

--- a/researchskills-extract/commands/SKILL.md
+++ b/researchskills-extract/commands/SKILL.md
@@ -98,11 +98,11 @@ Report: `"Classified N projects. Proceeding with M."`
 Read `~/.researchskills/cache/classification.json` and display:
 
 ```
-Select which projects to scan for research skills (all selected — deselect any you want to skip):
+Select which projects to scan for research skills (all research projects selected — deselect any project that is not related to research):
 
   [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
   [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
-  [x] 3. Personal Website             (3 sessions, engineering)
+  [ ] 3. Personal Website             (3 sessions, engineering)
   [x] 4. Dotfiles                     (2 sessions, other)
 
 Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none

--- a/researchskills-extract/commands/researchskills-extract.md
+++ b/researchskills-extract/commands/researchskills-extract.md
@@ -92,18 +92,18 @@ Report: `"Classified N projects. Proceeding with M."`
 Read `~/.researchskills/cache/classification.json` and display:
 
 ```
-Select which projects to scan for research skills (all selected — deselect any you want to skip):
+Select which projects to scan for research skills (all research projects selected — deselect any project that is not related to research):
 
   [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
   [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
-  [x] 3. Personal Website             (3 sessions, engineering)
+  [ ] 3. Personal Website             (3 sessions, engineering)
   [x] 4. Dotfiles                     (2 sessions, other)
 
 Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none
 Enter numbers to toggle, or press Enter to continue:
 ```
 
-All projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
+All research projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
 
 **YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Use AskUserQuestion to present the project list and block until the user replies. Do NOT continue to Stage 3 without an explicit user response.
 

--- a/researchskills-extract/commands/researchskills-extract.md
+++ b/researchskills-extract/commands/researchskills-extract.md
@@ -92,17 +92,18 @@ Report: `"Classified N projects. Proceeding with M."`
 Read `~/.researchskills/cache/classification.json` and display:
 
 ```
-Select which projects to scan for research skills:
+Select which projects to scan for research skills (all selected — deselect any you want to skip):
 
   [x] 1. Protein Folding Pipeline     (4 sessions, research, quantitative-biology)
   [x] 2. Quantum Monte Carlo Study    (3 sessions, research, physics)
-  [ ] 3. Personal Website             (3 sessions, engineering)
-  [ ] 4. Dotfiles                     (2 sessions, other)
+  [x] 3. Personal Website             (3 sessions, engineering)
+  [x] 4. Dotfiles                     (2 sessions, other)
 
+Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none
 Enter numbers to toggle, or press Enter to continue:
 ```
 
-Research projects are pre-selected; engineering/other are deselected.
+All projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
 
 **YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Use AskUserQuestion to present the project list and block until the user replies. Do NOT continue to Stage 3 without an explicit user response.
 

--- a/researchskills-extract/commands/researchskills-extract.md
+++ b/researchskills-extract/commands/researchskills-extract.md
@@ -99,11 +99,10 @@ Select which projects to scan for research skills (all research projects selecte
   [ ] 3. Personal Website             (3 sessions, engineering)
   [x] 4. Dotfiles                     (2 sessions, other)
 
-Shortcuts:  a = select all  |  r = research only  |  e = engineering only  |  n = select none
 Enter numbers to toggle, or press Enter to continue:
 ```
 
-All research projects are pre-selected by default. Users can deselect individual projects by number, or use shortcuts to bulk-toggle by category.
+All research projects are pre-selected by default. Users can deselect individual projects by number.
 
 **YOU MUST STOP HERE AND WAIT FOR THE USER TO RESPOND.** Use AskUserQuestion to present the project list and block until the user replies. Do NOT continue to Stage 3 without an explicit user response.
 


### PR DESCRIPTION
## Summary
- Changed Stage 2.5 (Project Consent Gate) to pre-select **all** projects by default instead of only research projects
- Added bulk-toggle shortcuts: `a` (all), `r` (research only), `e` (engineering only), `n` (none)
- Applied to both `researchskills-extract.md` (Claude Code) and `SKILL.md` (Codex)

## Why
With 17+ projects discovered, users had to manually select each one. The old default (research-only pre-selected) meant most users needed to toggle 13+ items. Selecting all by default and letting users deselect is faster.

## Test plan
- [ ] Run `/researchskills-extract` and verify all 17 projects appear pre-selected
- [ ] Verify deselecting individual projects by number still works
- [ ] Verify shortcut keys (a/r/e/n) are recognized by the LLM prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)