### PR TITLE
docs: add Method D for submitting existing skills via Claude Code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,9 @@ Already have research skills written down — in notes, documents, custom format
 I have research skills/knowledge that I'd like to contribute to ResearchSkills
 (https://github.com/ScienceIntelligence/ResearchSkills).
 
-Please help me convert them into the ResearchSkills format. Each skill should be a
+Please help me convert them into the ResearchSkills format. Only extract genuine
+**research** skills — skip generic software engineering, DevOps, textbook knowledge,
+or anything an LLM would already know from training data. Each skill should be a
 Markdown file with YAML frontmatter matching one of three memory types:
 
 **Procedural** (IF-THEN rules for research impasses):
@@ -147,6 +149,8 @@ IMPORTANT — De-identification: Before outputting the final files, remove all p
 names, private file paths, internal URLs, lab-specific identifiers, and any other
 information that could identify individuals or institutions. Replace them with
 anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
+All output must be in English. If the source material is in another language,
+paraphrase the content into English — do not preserve direct non-English quotes.
 
 Here are my skills to convert:
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,65 @@ After running, submit via [**here →**](https://researchskills.ai/submit-manual
 
 Write your own skill following the [**guide →**](https://researchskills.ai/submit-manually/#manual-entry)
 
+### Method D: Submit Existing Skills via Claude Code
+
+Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format and submit.
+
+**In Claude Code, run:**
+
+````
+I have research skills/knowledge that I'd like to contribute to ResearchSkills
+(https://github.com/ScienceIntelligence/ResearchSkills).
+
+Please help me convert them into the ResearchSkills format. Each skill should be a
+Markdown file with YAML frontmatter matching one of three memory types:
+
+**Procedural** (IF-THEN rules for research impasses):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: procedural
+subtype: tie | no-change | constraint-failure | operator-fail
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
+
+**Semantic** (domain facts LLMs don't reliably know):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: semantic
+subtype: frontier | non-public | correction
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## Fact, ## Evidence, ## LLM Default Belief, ## Expiry Signal
+
+**Episodic** (concrete research episodes):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: episodic
+subtype: failure | adaptation | anomalous
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
+
+Here are my skills to convert:
+
+<paste your skills here>
+````
+
+After Claude Code generates the files, fork [ResearchSkills](https://github.com/ScienceIntelligence/ResearchSkills), place each file under `skills/<domain>/<subdomain>/<your-username>/<memory_type>/`, and open a PR.
+
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -106,12 +106,15 @@ Please help me convert them into the ResearchSkills format. Only extract genuine
 or anything an LLM would already know from training data. Each skill should be a
 Markdown file with YAML frontmatter matching one of three memory types:
 
+For each skill, pick exactly ONE subtype from the options listed below.
+
 **Procedural** (IF-THEN rules for research impasses):
+- Subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: procedural
-subtype: tie | no-change | constraint-failure | operator-fail
+subtype: tie  # pick one: tie, no-change, constraint-failure, operator-fail
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>
@@ -120,11 +123,12 @@ contributor: <github-username>
 Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
 
 **Semantic** (domain facts LLMs don't reliably know):
+- Subtypes: `frontier`, `non-public`, `correction`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: semantic
-subtype: frontier | non-public | correction
+subtype: correction  # pick one: frontier, non-public, correction
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>
@@ -133,11 +137,12 @@ contributor: <github-username>
 Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
 **Episodic** (concrete research episodes):
+- Subtypes: `failure`, `adaptation`, `anomalous`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: episodic
-subtype: failure | adaptation | anomalous
+subtype: failure  # pick one: failure, adaptation, anomalous
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ Write your own skill following the [**guide →**](https://researchskills.ai/sub
 
 Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
 
+> **Privacy note:** Your pasted text is sent to the model provider (Anthropic). Remove any confidential or sensitive information (private URLs, internal file paths, proprietary data) from your source material **before** pasting.
+
 **In Claude Code, run:**
 
 ````
@@ -126,7 +128,7 @@ subdomain: <arXiv subdomain>
 contributor: <github-username>
 ---
 ```
-Sections: ## Fact, ## Evidence, ## LLM Default Belief, ## Expiry Signal
+Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
 **Episodic** (concrete research episodes):
 ```yaml

--- a/readme.md
+++ b/readme.md
@@ -89,80 +89,30 @@ After running, submit via [**here →**](https://researchskills.ai/submit-manual
 
 Write your own skill following the [**guide →**](https://researchskills.ai/submit-manually/#manual-entry)
 
-### Method D: Submit Existing Skills via Claude Code
+<details>
+<summary><strong>Method D: Submit Existing Skills via Claude Code / Codex</strong></summary>
 
-Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
+Already have research skills in notes, documents, or another AI tool's memory? Paste this prompt into Claude Code or Codex — it will ask you a few questions and handle the rest.
 
-> **Privacy note:** Your pasted text is sent to the model provider (Anthropic). Remove any confidential or sensitive information (private URLs, internal file paths, proprietary data) from your source material **before** pasting.
-
-**In Claude Code, run:**
-
-````
-I have research skills/knowledge that I'd like to contribute to ResearchSkills
-(https://github.com/ScienceIntelligence/ResearchSkills).
-
-Please help me convert them into the ResearchSkills format. Only extract genuine
-**research** skills — skip generic software engineering, DevOps, textbook knowledge,
-or anything an LLM would already know from training data. Each skill should be a
-Markdown file with YAML frontmatter matching one of three memory types:
-
-For each skill, pick exactly ONE subtype from the options listed below.
-
-**Procedural** (IF-THEN rules for research impasses):
-- Subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: procedural
-subtype: tie  # pick one: tie, no-change, constraint-failure, operator-fail
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
 ```
-Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
+I want to contribute my research skills to ResearchSkills (https://github.com/ScienceIntelligence/ResearchSkills). Please guide me through the process. Ask me these questions one at a time:
 
-**Semantic** (domain facts LLMs don't reliably know):
-- Subtypes: `frontier`, `non-public`, `correction`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: semantic
-subtype: correction  # pick one: frontier, non-public, correction
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
+1. Where are your skills? (a file path, a directory, or "I'll paste them here")
+2. What is your research domain? (e.g., physics/geophysics, computer-science/machine-learning)
+3. What is your GitHub username? (for the contributor field)
+
+After I answer, read the files (or my pasted text), then convert each skill into a ```skill-md fenced block. Only extract genuine research skills — skip generic software engineering, DevOps, or textbook knowledge. For each skill, pick the best memory_type and subtype:
+
+- procedural (tie | no-change | constraint-failure | operator-fail): Sections: When, Decision, Local Verifiers, Failure Handling, Anti-exemplars
+- semantic (frontier | non-public | correction): Sections: Fact, Evidence, LLM Default Belief (correction only), Expiry Signal
+- episodic (failure | adaptation | anomalous): Sections: Situation, Action, Outcome, Lesson, Retrieval Cues
+
+De-identify all output: remove personal names, private file paths, internal URLs, lab identifiers. All output must be in English. Then help me submit the results to researchskills.ai/submit-manually/#auto-parse.
 ```
-Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
-**Episodic** (concrete research episodes):
-- Subtypes: `failure`, `adaptation`, `anomalous`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: episodic
-subtype: failure  # pick one: failure, adaptation, anomalous
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
-```
-Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
+After Claude Code generates the output, paste it into [**researchskills.ai/submit-manually →**](https://researchskills.ai/submit-manually/#auto-parse) to review and submit.
 
-IMPORTANT — De-identification: Before outputting the final files, remove all personal
-names, private file paths, internal URLs, lab-specific identifiers, and any other
-information that could identify individuals or institutions. Replace them with
-anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
-All output must be in English. If the source material is in another language,
-paraphrase the content into English — do not preserve direct non-English quotes.
-
-Here are my skills to convert:
-
-<paste your skills here>
-````
-
-After Claude Code generates the files, review each one for any remaining personal or sensitive information, then submit via [**researchskills.ai →**](https://researchskills.ai/submit-manually/#auto-parse).
+</details>
 
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Write your own skill following the [**guide →**](https://researchskills.ai/sub
 
 ### Method D: Submit Existing Skills via Claude Code
 
-Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format and submit.
+Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
 
 **In Claude Code, run:**
 
@@ -141,12 +141,17 @@ contributor: <github-username>
 ```
 Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
 
+IMPORTANT — De-identification: Before outputting the final files, remove all personal
+names, private file paths, internal URLs, lab-specific identifiers, and any other
+information that could identify individuals or institutions. Replace them with
+anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
+
 Here are my skills to convert:
 
 <paste your skills here>
 ````
 
-After Claude Code generates the files, fork [ResearchSkills](https://github.com/ScienceIntelligence/ResearchSkills), place each file under `skills/<domain>/<subdomain>/<your-username>/<memory_type>/`, and open a PR.
+After Claude Code generates the files, review each one for any remaining personal or sensitive information, then submit via [**researchskills.ai →**](https://researchskills.ai/submit-manually/#auto-parse).
 
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 


### PR DESCRIPTION
## Summary

- Adds a fourth contribution option (Method D) to the README for researchers who already have skills in any format (notes, documents, other AI tool memories) and have Claude Code
- Provides a copy-paste prompt that explains all three memory types (procedural, semantic, episodic) with correct subtypes, required sections, and concrete YAML examples
- Includes privacy warning, de-identification instructions, research-only gating, and English-only output requirement
- Routes submission through researchskills.ai review page (not raw PR) to match existing validation flow

## Test plan

- [ ] Verify the prompt renders correctly in the README on GitHub
- [ ] Paste the prompt into Claude Code with sample research notes and confirm valid skill files are generated
- [ ] Confirm generated files pass `validate-skills.js` validation
- [ ] Verify the researchskills.ai/submit-manually/#auto-parse link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)