### PR TITLE
feat: add research skill templates, /researchskills-convert references, and updated contribution guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 - [ ] **Research Skill** — extracted via `/researchskills-extract`, converted via `/researchskills-convert`, or written by hand using the research skill templates
 - [ ] **Decision Tree** — research trajectory extracted via `/researchskills-extract` or web prompt
+- [ ] **Skill (from Gemini/ChatGPT/Claude Web UI)** — submit via [here](https://researchskills.ai/submit-manually)
 - [ ] **Skill (legacy)** — manually written skill file using the legacy template (`_template.md`)
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,24 @@
 ## Submission Type
 
+- [ ] **Research Skill** — extracted via `/researchskills-extract`, converted via `/researchskills-convert`, or written by hand using the research skill templates
 - [ ] **Decision Tree** — research trajectory extracted via `/researchskills-extract` or web prompt
-- [ ] **Skill** — manually written skill file
+- [ ] **Skill (legacy)** — manually written skill file using the legacy template (`_template.md`)
 
 ---
+
+### For Research Skill submissions:
+
+**Domain / Subdomain:** <!-- e.g. physics / geophysics -->
+
+- [ ] Files are placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
+- [ ] Filenames follow the pattern `<subtype>--<skill-name>.md` (lowercase, hyphen-separated)
+- [ ] All **required** frontmatter fields are filled in (`name`, `memory_type`, `subtype`, `domain`, `subdomain`, `contributor`)
+- [ ] All **required** body sections are present for each memory type:
+  - Procedural: When, Decision, Local Verifiers, Failure Handling
+  - Semantic: Fact, Evidence, Expiry Signal (+ LLM Default Belief for `correction`)
+  - Episodic: Situation, Action, Outcome, Lesson, Retrieval Cues
+- [ ] Content is de-identified (no personal names, private file paths, internal URLs)
+- [ ] All content is in English
 
 ### For Decision Tree submissions:
 
@@ -13,7 +28,7 @@
 - [ ] All nodes have valid action types (20 core types or `other`)
 - [ ] I have reviewed the tree for accuracy
 
-### For Skill submissions:
+### For Skill (legacy) submissions:
 
 **Domain:** <!-- e.g. physics / quantum-physics -->
 **Skill name:** <!-- value of the `name` frontmatter field -->

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,9 @@ Already have research skills written down — in notes, documents, custom format
 I have research skills/knowledge that I'd like to contribute to ResearchSkills
 (https://github.com/ScienceIntelligence/ResearchSkills).
 
-Please help me convert them into the ResearchSkills format. Each skill should be a
+Please help me convert them into the ResearchSkills format. Only extract genuine
+**research** skills — skip generic software engineering, DevOps, textbook knowledge,
+or anything an LLM would already know from training data. Each skill should be a
 Markdown file with YAML frontmatter matching one of three memory types:
 
 **Procedural** (IF-THEN rules for research impasses):
@@ -147,6 +149,8 @@ IMPORTANT — De-identification: Before outputting the final files, remove all p
 names, private file paths, internal URLs, lab-specific identifiers, and any other
 information that could identify individuals or institutions. Replace them with
 anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
+All output must be in English. If the source material is in another language,
+paraphrase the content into English — do not preserve direct non-English quotes.
 
 Here are my skills to convert:
 

--- a/readme.md
+++ b/readme.md
@@ -90,27 +90,25 @@ After running, submit via [**here →**](https://researchskills.ai/submit-manual
 Write your own skill following the [**guide →**](https://researchskills.ai/submit-manually/#manual-entry)
 
 <details>
-<summary><strong>Method D: Submit Existing Skills via Claude Code / Codex</strong></summary>
+<summary><strong>Method D: Convert Existing Skills via Claude Code / Codex</strong></summary>
 
-Already have research skills in notes, documents, or another AI tool's memory? Paste this prompt into Claude Code or Codex — it will ask you a few questions and handle the rest.
+Already have research skills in notes, documents, or any format? Run one command — it reads your files, converts them, and opens a PR.
 
-```
-I want to contribute my research skills to ResearchSkills (https://github.com/ScienceIntelligence/ResearchSkills). Please guide me through the process. Ask me these questions one at a time:
-
-1. Where are your skills? (a file path, a directory, or "I'll paste them here")
-2. What is your research domain? (e.g., physics/geophysics, computer-science/machine-learning)
-3. What is your GitHub username? (for the contributor field)
-
-After I answer, read the files (or my pasted text), then convert each skill into a ```skill-md fenced block. Only extract genuine research skills — skip generic software engineering, DevOps, or textbook knowledge. For each skill, pick the best memory_type and subtype:
-
-- procedural (tie | no-change | constraint-failure | operator-fail): Sections: When, Decision, Local Verifiers, Failure Handling, Anti-exemplars
-- semantic (frontier | non-public | correction): Sections: Fact, Evidence, LLM Default Belief (correction only), Expiry Signal
-- episodic (failure | adaptation | anomalous): Sections: Situation, Action, Outcome, Lesson, Retrieval Cues
-
-De-identify all output: remove personal names, private file paths, internal URLs, lab identifiers. All output must be in English. Then help me submit the results to researchskills.ai/submit-manually/#auto-parse.
+```bash
+npm install -g @scienceintelligence/researchskills-extract
 ```
 
-After Claude Code generates the output, paste it into [**researchskills.ai/submit-manually →**](https://researchskills.ai/submit-manually/#auto-parse) to review and submit.
+**Claude Code:**
+```
+/researchskills-convert
+```
+
+**Codex:**
+```
+$researchskills-convert
+```
+
+The command asks where your skills are, reads them, converts each one into the correct format, and opens a PR to this repository. Forking, branching, file placement, and de-identification are handled automatically.
 
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,65 @@ After running, submit via [**here →**](https://researchskills.ai/submit-manual
 
 Write your own skill following the [**guide →**](https://researchskills.ai/submit-manually/#manual-entry)
 
+### Method D: Submit Existing Skills via Claude Code
+
+Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format and submit.
+
+**In Claude Code, run:**
+
+````
+I have research skills/knowledge that I'd like to contribute to ResearchSkills
+(https://github.com/ScienceIntelligence/ResearchSkills).
+
+Please help me convert them into the ResearchSkills format. Each skill should be a
+Markdown file with YAML frontmatter matching one of three memory types:
+
+**Procedural** (IF-THEN rules for research impasses):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: procedural
+subtype: tie | no-change | constraint-failure | operator-fail
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
+
+**Semantic** (domain facts LLMs don't reliably know):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: semantic
+subtype: frontier | non-public | correction
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## Fact, ## Evidence, ## LLM Default Belief, ## Expiry Signal
+
+**Episodic** (concrete research episodes):
+```yaml
+---
+name: "descriptive-skill-name"
+memory_type: episodic
+subtype: failure | adaptation | anomalous
+domain: <arXiv domain>
+subdomain: <arXiv subdomain>
+contributor: <github-username>
+---
+```
+Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
+
+Here are my skills to convert:
+
+<paste your skills here>
+````
+
+After Claude Code generates the files, fork [ResearchSkills](https://github.com/ScienceIntelligence/ResearchSkills), place each file under `skills/<domain>/<subdomain>/<your-username>/<memory_type>/`, and open a PR.
+
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -106,12 +106,15 @@ Please help me convert them into the ResearchSkills format. Only extract genuine
 or anything an LLM would already know from training data. Each skill should be a
 Markdown file with YAML frontmatter matching one of three memory types:
 
+For each skill, pick exactly ONE subtype from the options listed below.
+
 **Procedural** (IF-THEN rules for research impasses):
+- Subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: procedural
-subtype: tie | no-change | constraint-failure | operator-fail
+subtype: tie  # pick one: tie, no-change, constraint-failure, operator-fail
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>
@@ -120,11 +123,12 @@ contributor: <github-username>
 Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
 
 **Semantic** (domain facts LLMs don't reliably know):
+- Subtypes: `frontier`, `non-public`, `correction`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: semantic
-subtype: frontier | non-public | correction
+subtype: correction  # pick one: frontier, non-public, correction
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>
@@ -133,11 +137,12 @@ contributor: <github-username>
 Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
 **Episodic** (concrete research episodes):
+- Subtypes: `failure`, `adaptation`, `anomalous`
 ```yaml
 ---
 name: "descriptive-skill-name"
 memory_type: episodic
-subtype: failure | adaptation | anomalous
+subtype: failure  # pick one: failure, adaptation, anomalous
 domain: <arXiv domain>
 subdomain: <arXiv subdomain>
 contributor: <github-username>

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ Write your own skill following the [**guide →**](https://researchskills.ai/sub
 
 Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
 
+> **Privacy note:** Your pasted text is sent to the model provider (Anthropic). Remove any confidential or sensitive information (private URLs, internal file paths, proprietary data) from your source material **before** pasting.
+
 **In Claude Code, run:**
 
 ````
@@ -126,7 +128,7 @@ subdomain: <arXiv subdomain>
 contributor: <github-username>
 ---
 ```
-Sections: ## Fact, ## Evidence, ## LLM Default Belief, ## Expiry Signal
+Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
 **Episodic** (concrete research episodes):
 ```yaml

--- a/readme.md
+++ b/readme.md
@@ -89,80 +89,30 @@ After running, submit via [**here →**](https://researchskills.ai/submit-manual
 
 Write your own skill following the [**guide →**](https://researchskills.ai/submit-manually/#manual-entry)
 
-### Method D: Submit Existing Skills via Claude Code
+<details>
+<summary><strong>Method D: Submit Existing Skills via Claude Code / Codex</strong></summary>
 
-Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
+Already have research skills in notes, documents, or another AI tool's memory? Paste this prompt into Claude Code or Codex — it will ask you a few questions and handle the rest.
 
-> **Privacy note:** Your pasted text is sent to the model provider (Anthropic). Remove any confidential or sensitive information (private URLs, internal file paths, proprietary data) from your source material **before** pasting.
-
-**In Claude Code, run:**
-
-````
-I have research skills/knowledge that I'd like to contribute to ResearchSkills
-(https://github.com/ScienceIntelligence/ResearchSkills).
-
-Please help me convert them into the ResearchSkills format. Only extract genuine
-**research** skills — skip generic software engineering, DevOps, textbook knowledge,
-or anything an LLM would already know from training data. Each skill should be a
-Markdown file with YAML frontmatter matching one of three memory types:
-
-For each skill, pick exactly ONE subtype from the options listed below.
-
-**Procedural** (IF-THEN rules for research impasses):
-- Subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: procedural
-subtype: tie  # pick one: tie, no-change, constraint-failure, operator-fail
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
 ```
-Sections: ## When, ## Decision, ## Local Verifiers, ## Failure Handling, ## Anti-exemplars
+I want to contribute my research skills to ResearchSkills (https://github.com/ScienceIntelligence/ResearchSkills). Please guide me through the process. Ask me these questions one at a time:
 
-**Semantic** (domain facts LLMs don't reliably know):
-- Subtypes: `frontier`, `non-public`, `correction`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: semantic
-subtype: correction  # pick one: frontier, non-public, correction
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
+1. Where are your skills? (a file path, a directory, or "I'll paste them here")
+2. What is your research domain? (e.g., physics/geophysics, computer-science/machine-learning)
+3. What is your GitHub username? (for the contributor field)
+
+After I answer, read the files (or my pasted text), then convert each skill into a ```skill-md fenced block. Only extract genuine research skills — skip generic software engineering, DevOps, or textbook knowledge. For each skill, pick the best memory_type and subtype:
+
+- procedural (tie | no-change | constraint-failure | operator-fail): Sections: When, Decision, Local Verifiers, Failure Handling, Anti-exemplars
+- semantic (frontier | non-public | correction): Sections: Fact, Evidence, LLM Default Belief (correction only), Expiry Signal
+- episodic (failure | adaptation | anomalous): Sections: Situation, Action, Outcome, Lesson, Retrieval Cues
+
+De-identify all output: remove personal names, private file paths, internal URLs, lab identifiers. All output must be in English. Then help me submit the results to researchskills.ai/submit-manually/#auto-parse.
 ```
-Sections: ## Fact, ## Evidence, ## LLM Default Belief (correction only), ## Expiry Signal
 
-**Episodic** (concrete research episodes):
-- Subtypes: `failure`, `adaptation`, `anomalous`
-```yaml
----
-name: "descriptive-skill-name"
-memory_type: episodic
-subtype: failure  # pick one: failure, adaptation, anomalous
-domain: <arXiv domain>
-subdomain: <arXiv subdomain>
-contributor: <github-username>
----
-```
-Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
+After Claude Code generates the output, paste it into [**researchskills.ai/submit-manually →**](https://researchskills.ai/submit-manually/#auto-parse) to review and submit.
 
-IMPORTANT — De-identification: Before outputting the final files, remove all personal
-names, private file paths, internal URLs, lab-specific identifiers, and any other
-information that could identify individuals or institutions. Replace them with
-anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
-All output must be in English. If the source material is in another language,
-paraphrase the content into English — do not preserve direct non-English quotes.
-
-Here are my skills to convert:
-
-<paste your skills here>
-````
-
-After Claude Code generates the files, review each one for any remaining personal or sensitive information, then submit via [**researchskills.ai →**](https://researchskills.ai/submit-manually/#auto-parse).
+</details>
 
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Write your own skill following the [**guide →**](https://researchskills.ai/sub
 
 ### Method D: Submit Existing Skills via Claude Code
 
-Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format and submit.
+Already have research skills written down — in notes, documents, custom formats, or another AI tool's memory? If you have Claude Code, paste the prompt below to translate them into ResearchSkills format.
 
 **In Claude Code, run:**
 
@@ -141,12 +141,17 @@ contributor: <github-username>
 ```
 Sections: ## Situation, ## Action, ## Outcome, ## Lesson, ## Retrieval Cues
 
+IMPORTANT — De-identification: Before outputting the final files, remove all personal
+names, private file paths, internal URLs, lab-specific identifiers, and any other
+information that could identify individuals or institutions. Replace them with
+anonymized placeholders (e.g., "a colleague", "internal tool", "our lab").
+
 Here are my skills to convert:
 
 <paste your skills here>
 ````
 
-After Claude Code generates the files, fork [ResearchSkills](https://github.com/ScienceIntelligence/ResearchSkills), place each file under `skills/<domain>/<subdomain>/<your-username>/<memory_type>/`, and open a PR.
+After Claude Code generates the files, review each one for any remaining personal or sensitive information, then submit via [**researchskills.ai →**](https://researchskills.ai/submit-manually/#auto-parse).
 
 > Don't see your field? [Propose a new area →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md) · Need a skill but can't write it yourself? [Request a skill →](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=02-skill-request.yml)
 

--- a/skills/_template-episodic.md
+++ b/skills/_template-episodic.md
@@ -1,0 +1,56 @@
+---
+name: your-skill-name
+memory_type: episodic
+subtype: failure                               # failure | adaptation | anomalous
+domain: physics                                # physics | mathematics | computer-science | quantitative-biology | statistics | eess | economics | quantitative-finance
+subdomain: geophysics                          # arXiv-aligned subdomain (see skills/<domain>/ for options)
+contributor: your-github-username
+---
+
+<!--
+  EPISODIC SKILL TEMPLATE
+  ───────────────────────
+  Episodic skills capture concrete research episodes as situation-action-outcome triples.
+  Dead ends and failures are often the most valuable — they prevent others from repeating mistakes.
+
+  Subtypes:
+    failure    — Attempted X, failed due to hidden reason Y
+    adaptation — Standard method failed, workaround Z succeeded
+    anomalous  — Expected A, observed B — turned out important
+
+  File placement:
+    skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<skill-name>.md
+    Example: skills/physics/geophysics/jdoe/episodic/failure--gradient-explosion-under-fp16.md
+
+  Instructions:
+    1. Fill in all frontmatter fields above.
+    2. Complete each section below. Favor specificity over generality — include exact
+       tool names, library versions, parameter values, hardware specs, error messages.
+    3. Delete these comment blocks before submitting.
+-->
+
+## Situation
+<!-- REQUIRED -->
+<!-- Be specific: what tools/libraries/hardware were involved? What dataset and parameters?
+     What stage of the project? What did you expect to happen? -->
+
+## Action
+<!-- REQUIRED -->
+<!-- What you actually did — include specific tool names, commands, parameter values,
+     library versions, and the reasoning behind each choice. -->
+
+## Outcome
+<!-- REQUIRED -->
+<!-- Concrete result — metrics, error messages, unexpected behavior.
+     Quantify where possible (e.g., "loss dropped from 2.3 to 0.8" not "loss improved"). -->
+
+## Lesson
+<!-- REQUIRED -->
+<!-- The key insight. State as a specific IF-THEN rule with conditions, not a vague principle.
+     E.g., "IF using Adam with fp16 AND loss spikes after epoch 3-5 THEN raise eps to 1e-5." -->
+
+## Retrieval Cues
+<!-- REQUIRED -->
+<!-- When should an AI agent recall this episode?
+     List specific trigger conditions, one per line — tool names, error patterns,
+     parameter ranges, dataset characteristics. -->

--- a/skills/_template-procedural.md
+++ b/skills/_template-procedural.md
@@ -1,0 +1,57 @@
+---
+name: your-skill-name
+memory_type: procedural
+subtype: tie                                   # tie | no-change | constraint-failure | operator-fail
+domain: physics                                # physics | mathematics | computer-science | quantitative-biology | statistics | eess | economics | quantitative-finance
+subdomain: geophysics                          # arXiv-aligned subdomain (see skills/<domain>/ for options)
+contributor: your-github-username
+---
+
+<!--
+  PROCEDURAL SKILL TEMPLATE
+  ─────────────────────────
+  Procedural skills capture IF-THEN decision rules for navigating research impasses.
+  They encode the tacit judgment calls that experienced researchers make when stuck.
+
+  Subtypes:
+    tie              — Multiple viable paths, unclear which to choose
+    no-change        — Completely stuck, no candidate action
+    constraint-failure — A methodological assumption turns out to be violated
+    operator-fail    — Correct approach selected but execution fails
+
+  File placement:
+    skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<skill-name>.md
+    Example: skills/physics/geophysics/jdoe/procedural/tie--exploiting-cross-domain-concepts.md
+
+  Instructions:
+    1. Fill in all frontmatter fields above.
+    2. Complete each section below. Be specific — include tool names, parameter values, library versions.
+    3. Delete these comment blocks before submitting.
+-->
+
+## When
+<!-- REQUIRED -->
+<!-- Precise trigger conditions: when does this impasse arise?
+     Include exclusions — situations that look similar but where this skill does NOT apply. -->
+
+## Decision
+<!-- REQUIRED -->
+<!-- What to do:
+     Preferred: [the recommended action and why]
+     Rejected: [alternatives you considered and why they were rejected]
+     Reasoning: [the mechanism — why does the preferred action work?] -->
+
+## Local Verifiers
+<!-- REQUIRED -->
+<!-- How to check if the approach is working.
+     Concrete diagnostics: metric thresholds, commands to run, patterns to look for. -->
+
+## Failure Handling
+<!-- REQUIRED -->
+<!-- What to do if the preferred action doesn't work.
+     Next steps, fallback strategies, escalation criteria. -->
+
+## Anti-exemplars
+<!-- RECOMMENDED -->
+<!-- When NOT to use this skill. Situations that superficially match the trigger
+     but where applying this decision would be wrong. -->

--- a/skills/_template-semantic.md
+++ b/skills/_template-semantic.md
@@ -1,0 +1,51 @@
+---
+name: your-skill-name
+memory_type: semantic
+subtype: correction                            # frontier | non-public | correction
+domain: physics                                # physics | mathematics | computer-science | quantitative-biology | statistics | eess | economics | quantitative-finance
+subdomain: geophysics                          # arXiv-aligned subdomain (see skills/<domain>/ for options)
+contributor: your-github-username
+---
+
+<!--
+  SEMANTIC SKILL TEMPLATE
+  ───────────────────────
+  Semantic skills capture domain facts that LLMs don't reliably know.
+  They correct model blind spots with evidence-backed knowledge.
+
+  Subtypes:
+    frontier    — Post-training-cutoff knowledge that doesn't exist in model weights
+    non-public  — Lab-internal or unpublished knowledge, never in any training corpus
+    correction  — LLM actively gets this wrong — confident but incorrect default belief
+
+  File placement:
+    skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<skill-name>.md
+    Example: skills/physics/geophysics/jdoe/semantic/correction--lsm-grid-resolution-is-a-design-choice.md
+
+  Instructions:
+    1. Fill in all frontmatter fields above.
+    2. Complete each section below. Be precise and cite evidence.
+    3. The "LLM Default Belief" section is only required for the `correction` subtype.
+    4. Delete these comment blocks before submitting.
+-->
+
+## Fact
+<!-- REQUIRED -->
+<!-- The core claim. State it precisely and unambiguously.
+     Include quantitative details where possible. -->
+
+## Evidence
+<!-- REQUIRED -->
+<!-- How you know this is true.
+     Cite papers, experiments, direct observation, or domain expertise.
+     Be specific enough that a reviewer can verify. -->
+
+## LLM Default Belief
+<!-- REQUIRED for `correction` subtype only. DELETE this section for `frontier` and `non-public`. -->
+<!-- What does the AI wrongly think? Describe the specific misconception
+     and why it's prevalent in training data. -->
+
+## Expiry Signal
+<!-- REQUIRED -->
+<!-- When should this skill be revisited or retired?
+     What would change to make this fact outdated? -->

--- a/utils/CONTRIBUTING.md
+++ b/utils/CONTRIBUTING.md
@@ -1,13 +1,14 @@
 # Contributing to ResearchSkills
 
-Thank you for contributing your expertise! There are two ways to contribute:
+Thank you for contributing your expertise! There are three ways to contribute:
 
-1. **Research Skills (recommended):** Use `/researchskills-extract` to automatically extract research skills from AI conversation history. This is the primary contribution method.
-2. **Skills (manual):** Write a skill file by hand following the template.
+1. **Extract from AI history (recommended):** Use `/researchskills-extract` to automatically extract research skills from your Claude Code or Codex conversation history.
+2. **Convert existing skills:** Use `/researchskills-convert` to convert skills you already have (notes, documents, any format) into ResearchSkills format and open a PR.
+3. **Write manually:** Write a skill file by hand following the templates.
 
 ---
 
-## 1. Submit Research Skills (Recommended)
+## 1. Extract from AI History (Recommended)
 
 ### Via Claude Code / Codex
 
@@ -26,44 +27,61 @@ https://researchskills.ai/submit-manually
 
 ---
 
-## 2. Write a Skill Manually
+## 2. Convert Existing Skills
 
-### 2.1 Fork & clone
+Already have research skills in notes, documents, or any format? Use `/researchskills-convert` to convert them and open a PR — all in one step.
+
+```bash
+npm install -g @scienceintelligence/researchskills-extract
+```
+
+Then in Claude Code: `/researchskills-convert`
+Or in Codex: `$researchskills-convert`
+
+The command will ask where your skills are (file path or directory), read them, convert each one into the correct format, and open a PR to this repository. It handles forking, branching, file placement, and de-identification automatically.
+
+---
+
+## 3. Write a Skill Manually
+
+### 3.1 Fork & clone
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/ResearchSkills.git
 cd ResearchSkills
 ```
 
-### 2.2 Create your skill file
+### 3.2 Create your skill file
 
-Copy the template and place it in the correct subdomain folder:
-
-```bash
-cp skills/_template.md skills/<domain>/<subdomain>/<your-skill-name>.md
-```
-
-**File naming:** lowercase, hyphen-separated. Examples:
-- `skills/physics/quantum-physics/quantum-entanglement.md`
-- `skills/computer-science/machine-learning/transformer-architectures.md`
-
-### 2.3 Fill in the template
-
-Open your new file and complete every section. See [SKILL_SCHEMA.md](SKILL_SCHEMA.md) for a full description of each frontmatter field.
-
-Required frontmatter fields:
-- `name`, `description`, `domain`, `author`, `expertise_level`, `status`
-
-### 2.4 Validate locally (optional but recommended)
+Pick the template matching your skill type and copy it to the correct location:
 
 ```bash
-python utils/tools/validate.py skills/<domain>/<subdomain>/<your-skill-name>.md
+# Procedural — IF-THEN rules for research decisions
+cp skills/_template-procedural.md skills/<domain>/<subdomain>/<your-username>/procedural/<subtype>--<skill-name>.md
+
+# Semantic — domain facts LLMs don't reliably know
+cp skills/_template-semantic.md skills/<domain>/<subdomain>/<your-username>/semantic/<subtype>--<skill-name>.md
+
+# Episodic — concrete research episodes
+cp skills/_template-episodic.md skills/<domain>/<subdomain>/<your-username>/episodic/<subtype>--<skill-name>.md
 ```
 
-### 2.5 Open a Pull Request
+**File naming:** `<subtype>--<skill-name>.md`, lowercase, hyphen-separated. Examples:
+- `skills/physics/geophysics/jdoe/procedural/tie--exploiting-cross-domain-concepts.md`
+- `skills/computer-science/machine-learning/jdoe/semantic/correction--batch-norm-placement.md`
+- `skills/physics/geophysics/jdoe/episodic/failure--gradient-explosion-under-fp16.md`
+
+> The legacy template (`skills/_template.md`) is still supported for backward compatibility.
+
+### 3.3 Fill in the template
+
+Open your new file and complete every section. Required frontmatter fields:
+- `name`, `memory_type`, `subtype`, `domain`, `subdomain`, `contributor`
+
+### 3.4 Open a Pull Request
 
 - Target branch: `main`
-- Title format: `[<domain>/<subdomain>] Add <skill-name> skill`
+- Title format: `[<domain>/<subdomain>] Add <skill-name> research skill`
 - The PR template will prompt you for a checklist
 
 A domain reviewer listed in [CODEOWNERS](../.github/CODEOWNERS) will review your submission for scientific accuracy.
@@ -104,14 +122,15 @@ Open a GitHub Discussion or reach out to the core team via issues.
 
 # 贡献指南（中文）
 
-感谢你贡献专业知识！有两种贡献方式：
+感谢你贡献专业知识！有三种贡献方式：
 
-1. **科研技能（推荐）：** 使用 `/researchskills-extract` 从 AI 对话历史中自动提取科研技能。这是主要的贡献方式。
-2. **Skill（手动）：** 参照模板手动撰写 Skill 文件。
+1. **从 AI 历史中提取（推荐）：** 使用 `/researchskills-extract` 从 Claude Code 或 Codex 对话历史中自动提取科研技能。
+2. **转换已有技能：** 使用 `/researchskills-convert` 将你已有的技能（笔记、文档、任何格式）转换为 ResearchSkills 格式并自动提交 PR。
+3. **手动撰写：** 参照模板手动撰写 Skill 文件。
 
 ---
 
-## 1. 提交科研技能（推荐）
+## 1. 从 AI 历史中提取（推荐）
 
 ### 通过 Claude Code / Codex
 
@@ -130,54 +149,70 @@ https://researchskills.ai/submit-manually
 
 ---
 
-## 2. 手动撰写 Skill
+## 2. 转换已有技能
 
-### 2.1 Fork 并克隆仓库
+已有科研技能记录——笔记、文档或任何格式？使用 `/researchskills-convert` 一键转换并提交 PR。
+
+```bash
+npm install -g @scienceintelligence/researchskills-extract
+```
+
+在 Claude Code 中运行: `/researchskills-convert`
+在 Codex 中运行: `$researchskills-convert`
+
+该命令会询问你的技能文件位置（文件路径或目录），读取并转换为正确格式，然后自动向本仓库提交 PR。Fork、分支创建、文件放置和去标识化均自动完成。
+
+---
+
+## 3. 手动撰写 Skill
+
+### 3.1 Fork 并克隆仓库
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/ResearchSkills.git
 cd ResearchSkills
 ```
 
-### 2.2 创建你的 Skill 文件
+### 3.2 创建你的 Skill 文件
 
-复制模板，放置到对应子领域文件夹：
-
-```bash
-cp skills/_template.md skills/<领域>/<子领域>/<你的skill名称>.md
-```
-
-**命名规范：** 小写字母，用连字符分隔。
-
-### 2.3 填写模板
-
-打开新文件，完成每个部分。参阅 [SKILL_SCHEMA.md](SKILL_SCHEMA.md) 了解各字段说明。
-
-必填 frontmatter 字段：
-- `name`、`description`、`domain`、`author`、`expertise_level`、`status`
-
-### 2.4 本地验证（推荐）
+选择对应类型的模板，复制到正确位置：
 
 ```bash
-python utils/tools/validate.py skills/<领域>/<子领域>/<你的skill名称>.md
+# 程序性 — 科研决策的 IF-THEN 规则
+cp skills/_template-procedural.md skills/<领域>/<子领域>/<用户名>/procedural/<子类型>--<技能名>.md
+
+# 语义性 — LLM 不可靠掌握的领域知识
+cp skills/_template-semantic.md skills/<领域>/<子领域>/<用户名>/semantic/<子类型>--<技能名>.md
+
+# 情景性 — 具体科研经历
+cp skills/_template-episodic.md skills/<领域>/<子领域>/<用户名>/episodic/<子类型>--<技能名>.md
 ```
 
-### 2.5 提交 Pull Request
+**命名规范：** `<子类型>--<技能名>.md`，小写字母，用连字符分隔。
+
+> 旧版模板（`skills/_template.md`）仍然支持向后兼容。
+
+### 3.3 填写模板
+
+打开新文件，完成每个部分。必填 frontmatter 字段：
+- `name`、`memory_type`、`subtype`、`domain`、`subdomain`、`contributor`
+
+### 3.4 提交 Pull Request
 
 - 目标分支：`main`
-- 标题格式：`[<领域>/<子领域>] Add <skill名称> skill`
+- 标题格式：`[<领域>/<子领域>] Add <技能名> research skill`
 
 [CODEOWNERS](../.github/CODEOWNERS) 中列出的领域维护者将审核你的提交。
 
 ---
 
-## 3. 提议新领域或子领域
+## 4. 提议新领域或子领域
 
 所有 155 个 arXiv 对齐的子领域文件夹已预创建在 `skills/` 下。如果你认为缺少某个子领域或想提议新的顶层领域，[**提交 Issue →**](https://github.com/ScienceIntelligence/ResearchSkills/issues/new?template=04-propose-new-area.md)
 
 ---
 
-## 4. 审核流程
+## 5. 审核流程
 
 | 阶段 | 负责人 | 检查内容 |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Add three new skill templates for the extracted/converted format: `_template-procedural.md`, `_template-semantic.md`, `_template-episodic.md`
- Update PR template: add "Research Skill" as primary submission type with correct checklist
- Update CONTRIBUTING.md (EN + ZH): add `/researchskills-convert` as Method 2, update manual method to reference new templates
- Update README: Method D references `/researchskills-convert` skill (collapsed by default)

## Test plan

- [ ] Verify all three templates have correct frontmatter fields and sections
- [ ] Verify PR template renders correctly with the new Research Skill checklist
- [ ] Verify CONTRIBUTING.md file placement examples match actual repo structure
- [ ] Verify README Method D renders as collapsed `<details>` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)