### PR TITLE
feat: add /researchskills-convert skill

### DIFF
--- a/researchskills-extract/commands/CONVERT-SKILL.md
+++ b/researchskills-extract/commands/CONVERT-SKILL.md
@@ -1,0 +1,268 @@
+---
+name: "researchskills-convert"
+description: "Convert existing research skills from any format into ResearchSkills format, then fork the repo and open a PR."
+---
+# /researchskills-convert
+
+Convert existing research skills from any format (notes, documents, other AI tools) into **ResearchSkills** format, then fork the repo and open a PR — all in one step.
+
+**This is an interactive skill.** Ask the user ONE question at a time. Do not dump all questions at once.
+
+---
+
+## Stage 1 — Collect Input
+
+Ask the user:
+
+> **Where are your skills?**
+> Provide a file path, a directory, or paste them here.
+
+Read the files or accept the pasted text. If a directory, recursively read all `.md`, `.txt`, `.json`, and `.yaml` files in it.
+
+---
+
+## Stage 2 — Identify the User
+
+Get the GitHub username for the `contributor` field:
+
+```bash
+gh api user --jq '.login'
+```
+
+If `gh` is not installed or not authenticated, tell the user:
+
+> `gh` (GitHub CLI) is required for PR creation. Install it:
+> - macOS: `brew install gh`
+> - Linux: see https://cli.github.com
+>
+> Then run `gh auth login` to authenticate.
+
+**Stop here until `gh api user` succeeds.**
+
+---
+
+## Stage 3 — Convert Skills
+
+Analyze the input and convert each genuine **research** skill into the ResearchSkills format. Apply these filters:
+
+### What to INCLUDE
+- Domain-specific research insights a researcher would find non-obvious
+- Methodology decisions, scientific corrections, experimental lessons
+- Knowledge that is frontier, non-public, or corrects LLM misconceptions
+
+### What to SKIP
+- Generic software engineering (git workflows, CI/CD, Docker, deployment)
+- DevOps, infrastructure, or tooling knowledge
+- Textbook material readily available in LLM training data
+- Content that is not related to scientific research
+
+### Memory Types and Required Sections
+
+**Procedural** (subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`)
+- When — trigger conditions and exclusions
+- Decision — Preferred, Rejected, Reasoning
+- Local Verifiers — concrete diagnostics
+- Failure Handling — fallback strategies
+- Anti-exemplars — when NOT to use (recommended)
+
+**Semantic** (subtypes: `frontier`, `non-public`, `correction`)
+- Fact — precise core claim
+- Evidence — how you know this is true
+- LLM Default Belief — **correction subtype only**, delete for others
+- Expiry Signal — when to revisit
+
+**Episodic** (subtypes: `failure`, `adaptation`, `anomalous`)
+- Situation — tools, dataset, parameters, expectations
+- Action — what was done, with specifics
+- Outcome — concrete result with metrics
+- Lesson — specific IF-THEN rule
+- Retrieval Cues — trigger conditions for recall
+
+### Frontmatter
+
+Every skill file must have this exact frontmatter:
+
+```yaml
+---
+name: "Skill Name In Title Case"
+memory_type: procedural          # procedural | semantic | episodic
+subtype: tie                     # see subtypes above
+domain: computer-science         # see domain list below
+subdomain: machine-learning      # arXiv-aligned subdomain
+contributor: gh-username          # from Stage 2
+---
+```
+
+### Valid Domains
+
+Pick from these arXiv-aligned domains:
+- `physics`
+- `mathematics`
+- `computer-science`
+- `quantitative-biology`
+- `statistics`
+- `eess` (electrical engineering and systems science)
+- `economics`
+- `quantitative-finance`
+
+For subdomain, use an arXiv-aligned subcategory (e.g., `machine-learning`, `geophysics`, `genomics`, `methodology`).
+
+### De-identification
+
+Before outputting, strip:
+- Personal names (replace with role descriptions)
+- Private file paths (use generic paths)
+- Internal URLs and hostnames
+- Lab-specific identifiers
+- API keys, tokens, credentials
+
+All output MUST be in English. If source material is in another language, paraphrase in English.
+
+---
+
+## Stage 4 — Show Preview
+
+Show the user all converted skills in a summary table:
+
+```
+Converted N skills:
+
+  #  Type         Subtype              Domain / Subdomain                   Name
+  1  procedural   constraint-failure   statistics / methodology             AUC Computation With Masked Data
+  2  semantic     correction           computer-science / machine-learning  Batch Norm Placement Misconception
+  3  episodic     adaptation           physics / geophysics                 Gradient Explosion Under FP16
+
+Proceed with forking and PR creation? (y/n)
+```
+
+**STOP and wait for user confirmation.** Do not proceed without explicit consent.
+
+If the user wants to edit, adjust, or remove specific skills, do so before proceeding.
+
+---
+
+## Stage 5 — Fork and Create PR
+
+### 5.1 — Check for existing fork
+
+```bash
+gh repo view "$(gh api user --jq '.login')/ResearchSkills" --json name 2>/dev/null
+```
+
+If no fork exists:
+
+```bash
+gh repo fork ScienceIntelligence/ResearchSkills --clone=false
+```
+
+### 5.2 — Clone the fork into a temp directory
+
+```bash
+WORK_DIR=$(mktemp -d)
+gh repo clone "$(gh api user --jq '.login')/ResearchSkills" "$WORK_DIR" -- --depth=1
+cd "$WORK_DIR"
+git remote add upstream https://github.com/ScienceIntelligence/ResearchSkills.git
+git fetch upstream main --depth=1
+git reset --hard upstream/main
+```
+
+### 5.3 — Create a branch
+
+```bash
+BRANCH="convert/$(gh api user --jq '.login')-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH"
+```
+
+### 5.4 — Place skill files
+
+Each skill must be placed at the correct path. **Create directories that don't exist.**
+
+```
+skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<skill-name>.md
+```
+
+Rules:
+- `<domain>` — lowercase (e.g., `computer-science`)
+- `<subdomain>` — lowercase, hyphen-separated (e.g., `machine-learning`)
+- `<contributor>` — GitHub username from Stage 2
+- `<memory_type>` — `procedural`, `semantic`, or `episodic`
+- `<subtype>--<skill-name>` — lowercase, hyphen-separated (e.g., `correction--batch-norm-placement-misconception.md`)
+
+Example paths:
+```
+skills/statistics/methodology/jdoe/procedural/constraint-failure--auc-computation-with-masked-data.md
+skills/computer-science/machine-learning/jdoe/semantic/correction--batch-norm-placement-misconception.md
+skills/physics/geophysics/jdoe/episodic/adaptation--gradient-explosion-under-fp16.md
+```
+
+For each skill:
+
+```bash
+SKILL_DIR="skills/<domain>/<subdomain>/<contributor>/<memory_type>"
+mkdir -p "$SKILL_DIR"
+```
+
+Then write the skill file to `$SKILL_DIR/<subtype>--<skill-name>.md`.
+
+### 5.5 — Commit
+
+```bash
+git add skills/
+git commit -m "add(skills): N skills by <contributor>"
+```
+
+### 5.6 — Push and create PR
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+Create a PR to the upstream repo:
+
+```bash
+gh pr create \
+  --repo ScienceIntelligence/ResearchSkills \
+  --head "$(gh api user --jq '.login'):$BRANCH" \
+  --title "[convert] Add N research skills by <contributor>" \
+  --body "$(cat <<'EOF'
+## Submission Type
+- [x] Research Skill (converted from existing notes/documents via `/researchskills-convert`)
+
+## Skills Added
+<list each skill: type, subtype, domain/subdomain, name>
+
+## Checklist
+- [x] Files placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
+- [x] Filenames follow pattern `<subtype>--<skill-name>.md`
+- [x] All required frontmatter fields filled
+- [x] All required body sections present
+- [x] Content is de-identified
+- [x] All content in English
+EOF
+)"
+```
+
+### 5.7 — Clean up
+
+```bash
+rm -rf "$WORK_DIR"
+```
+
+---
+
+## Stage 6 — Report
+
+Show the user:
+
+```
+═══════════════════════════════════════════════════════
+  /researchskills-convert — Done!
+═══════════════════════════════════════════════════════
+
+  Submitted N skills via PR:
+    → <PR URL>
+
+  A domain reviewer will review your PR and merge it.
+  You can track the status on GitHub.
+═══════════════════════════════════════════════════════
+```

--- a/researchskills-extract/commands/CONVERT-SKILL.md
+++ b/researchskills-extract/commands/CONVERT-SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "researchskills-convert"
-description: "Convert existing research skills from any format into ResearchSkills format, then fork the repo and open a PR."
+description: "Convert existing research skills from any format (notes, documents, other AI tools) into ResearchSkills format, then fork the repo and open a PR. Use when the user says 'convert my skills', 'submit existing skills', 'I already have research notes', 'turn my notes into ResearchSkills', 'convert from another format', or wants to contribute skills they already wrote in a different format."
 ---
 # /researchskills-convert
 
@@ -135,7 +135,7 @@ Converted N skills:
 Proceed with forking and PR creation? (y/n)
 ```
 
-**STOP and wait for user confirmation.** Do not proceed without explicit consent.
+**STOP and wait for user confirmation.** Use `ask` (Codex) or print the table and end your turn so the user's next message is their response. Do not proceed without explicit consent.
 
 If the user wants to edit, adjust, or remove specific skills, do so before proceeding.
 
@@ -229,7 +229,7 @@ gh pr create \
 - [x] Research Skill (converted from existing notes/documents via `/researchskills-convert`)
 
 ## Skills Added
-<list each skill: type, subtype, domain/subdomain, name>
+<!-- Fill this in: one line per skill, e.g. "- procedural / constraint-failure — statistics/methodology — AUC Computation With Masked Data" -->
 
 ## Checklist
 - [x] Files placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
@@ -244,9 +244,13 @@ EOF
 
 ### 5.7 — Clean up
 
+Only clean up after the PR was successfully created:
+
 ```bash
 rm -rf "$WORK_DIR"
 ```
+
+If any step in Stage 5 fails (fork, clone, push, or PR creation), show the error to the user and suggest manual steps to recover. Do not silently swallow errors.
 
 ---
 

--- a/researchskills-extract/commands/researchskills-convert.md
+++ b/researchskills-extract/commands/researchskills-convert.md
@@ -1,0 +1,264 @@
+# /researchskills-convert
+
+Convert existing research skills from any format (notes, documents, other AI tools) into **ResearchSkills** format, then fork the repo and open a PR — all in one step.
+
+**This is an interactive skill.** Ask the user ONE question at a time. Do not dump all questions at once.
+
+---
+
+## Stage 1 — Collect Input
+
+Ask the user:
+
+> **Where are your skills?**
+> Provide a file path, a directory, or paste them here.
+
+Read the files or accept the pasted text. If a directory, recursively read all `.md`, `.txt`, `.json`, and `.yaml` files in it.
+
+---
+
+## Stage 2 — Identify the User
+
+Get the GitHub username for the `contributor` field:
+
+```bash
+gh api user --jq '.login'
+```
+
+If `gh` is not installed or not authenticated, tell the user:
+
+> `gh` (GitHub CLI) is required for PR creation. Install it:
+> - macOS: `brew install gh`
+> - Linux: see https://cli.github.com
+>
+> Then run `gh auth login` to authenticate.
+
+**Stop here until `gh api user` succeeds.**
+
+---
+
+## Stage 3 — Convert Skills
+
+Analyze the input and convert each genuine **research** skill into the ResearchSkills format. Apply these filters:
+
+### What to INCLUDE
+- Domain-specific research insights a researcher would find non-obvious
+- Methodology decisions, scientific corrections, experimental lessons
+- Knowledge that is frontier, non-public, or corrects LLM misconceptions
+
+### What to SKIP
+- Generic software engineering (git workflows, CI/CD, Docker, deployment)
+- DevOps, infrastructure, or tooling knowledge
+- Textbook material readily available in LLM training data
+- Content that is not related to scientific research
+
+### Memory Types and Required Sections
+
+**Procedural** (subtypes: `tie`, `no-change`, `constraint-failure`, `operator-fail`)
+- When — trigger conditions and exclusions
+- Decision — Preferred, Rejected, Reasoning
+- Local Verifiers — concrete diagnostics
+- Failure Handling — fallback strategies
+- Anti-exemplars — when NOT to use (recommended)
+
+**Semantic** (subtypes: `frontier`, `non-public`, `correction`)
+- Fact — precise core claim
+- Evidence — how you know this is true
+- LLM Default Belief — **correction subtype only**, delete for others
+- Expiry Signal — when to revisit
+
+**Episodic** (subtypes: `failure`, `adaptation`, `anomalous`)
+- Situation — tools, dataset, parameters, expectations
+- Action — what was done, with specifics
+- Outcome — concrete result with metrics
+- Lesson — specific IF-THEN rule
+- Retrieval Cues — trigger conditions for recall
+
+### Frontmatter
+
+Every skill file must have this exact frontmatter:
+
+```yaml
+---
+name: "Skill Name In Title Case"
+memory_type: procedural          # procedural | semantic | episodic
+subtype: tie                     # see subtypes above
+domain: computer-science         # see domain list below
+subdomain: machine-learning      # arXiv-aligned subdomain
+contributor: gh-username          # from Stage 2
+---
+```
+
+### Valid Domains
+
+Pick from these arXiv-aligned domains:
+- `physics`
+- `mathematics`
+- `computer-science`
+- `quantitative-biology`
+- `statistics`
+- `eess` (electrical engineering and systems science)
+- `economics`
+- `quantitative-finance`
+
+For subdomain, use an arXiv-aligned subcategory (e.g., `machine-learning`, `geophysics`, `genomics`, `methodology`).
+
+### De-identification
+
+Before outputting, strip:
+- Personal names (replace with role descriptions)
+- Private file paths (use generic paths)
+- Internal URLs and hostnames
+- Lab-specific identifiers
+- API keys, tokens, credentials
+
+All output MUST be in English. If source material is in another language, paraphrase in English.
+
+---
+
+## Stage 4 — Show Preview
+
+Show the user all converted skills in a summary table:
+
+```
+Converted N skills:
+
+  #  Type         Subtype              Domain / Subdomain                   Name
+  1  procedural   constraint-failure   statistics / methodology             AUC Computation With Masked Data
+  2  semantic     correction           computer-science / machine-learning  Batch Norm Placement Misconception
+  3  episodic     adaptation           physics / geophysics                 Gradient Explosion Under FP16
+
+Proceed with forking and PR creation? (y/n)
+```
+
+**STOP and wait for user confirmation.** Do not proceed without explicit consent.
+
+If the user wants to edit, adjust, or remove specific skills, do so before proceeding.
+
+---
+
+## Stage 5 — Fork and Create PR
+
+### 5.1 — Check for existing fork
+
+```bash
+gh repo view "$(gh api user --jq '.login')/ResearchSkills" --json name 2>/dev/null
+```
+
+If no fork exists:
+
+```bash
+gh repo fork ScienceIntelligence/ResearchSkills --clone=false
+```
+
+### 5.2 — Clone the fork into a temp directory
+
+```bash
+WORK_DIR=$(mktemp -d)
+gh repo clone "$(gh api user --jq '.login')/ResearchSkills" "$WORK_DIR" -- --depth=1
+cd "$WORK_DIR"
+git remote add upstream https://github.com/ScienceIntelligence/ResearchSkills.git
+git fetch upstream main --depth=1
+git reset --hard upstream/main
+```
+
+### 5.3 — Create a branch
+
+```bash
+BRANCH="convert/$(gh api user --jq '.login')-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH"
+```
+
+### 5.4 — Place skill files
+
+Each skill must be placed at the correct path. **Create directories that don't exist.**
+
+```
+skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<skill-name>.md
+```
+
+Rules:
+- `<domain>` — lowercase (e.g., `computer-science`)
+- `<subdomain>` — lowercase, hyphen-separated (e.g., `machine-learning`)
+- `<contributor>` — GitHub username from Stage 2
+- `<memory_type>` — `procedural`, `semantic`, or `episodic`
+- `<subtype>--<skill-name>` — lowercase, hyphen-separated (e.g., `correction--batch-norm-placement-misconception.md`)
+
+Example paths:
+```
+skills/statistics/methodology/jdoe/procedural/constraint-failure--auc-computation-with-masked-data.md
+skills/computer-science/machine-learning/jdoe/semantic/correction--batch-norm-placement-misconception.md
+skills/physics/geophysics/jdoe/episodic/adaptation--gradient-explosion-under-fp16.md
+```
+
+For each skill:
+
+```bash
+SKILL_DIR="skills/<domain>/<subdomain>/<contributor>/<memory_type>"
+mkdir -p "$SKILL_DIR"
+```
+
+Then write the skill file to `$SKILL_DIR/<subtype>--<skill-name>.md`.
+
+### 5.5 — Commit
+
+```bash
+git add skills/
+git commit -m "add(skills): N skills by <contributor>"
+```
+
+### 5.6 — Push and create PR
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+Create a PR to the upstream repo:
+
+```bash
+gh pr create \
+  --repo ScienceIntelligence/ResearchSkills \
+  --head "$(gh api user --jq '.login'):$BRANCH" \
+  --title "[convert] Add N research skills by <contributor>" \
+  --body "$(cat <<'EOF'
+## Submission Type
+- [x] Research Skill (converted from existing notes/documents via `/researchskills-convert`)
+
+## Skills Added
+<list each skill: type, subtype, domain/subdomain, name>
+
+## Checklist
+- [x] Files placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
+- [x] Filenames follow pattern `<subtype>--<skill-name>.md`
+- [x] All required frontmatter fields filled
+- [x] All required body sections present
+- [x] Content is de-identified
+- [x] All content in English
+EOF
+)"
+```
+
+### 5.7 — Clean up
+
+```bash
+rm -rf "$WORK_DIR"
+```
+
+---
+
+## Stage 6 — Report
+
+Show the user:
+
+```
+═══════════════════════════════════════════════════════
+  /researchskills-convert — Done!
+═══════════════════════════════════════════════════════
+
+  Submitted N skills via PR:
+    → <PR URL>
+
+  A domain reviewer will review your PR and merge it.
+  You can track the status on GitHub.
+═══════════════════════════════════════════════════════
+```

--- a/researchskills-extract/commands/researchskills-convert.md
+++ b/researchskills-extract/commands/researchskills-convert.md
@@ -131,7 +131,7 @@ Converted N skills:
 Proceed with forking and PR creation? (y/n)
 ```
 
-**STOP and wait for user confirmation.** Do not proceed without explicit consent.
+**STOP and wait for user confirmation.** Use AskUserQuestion (Claude Code) to present the table and block until the user replies. Do not proceed without explicit consent.
 
 If the user wants to edit, adjust, or remove specific skills, do so before proceeding.
 
@@ -225,7 +225,7 @@ gh pr create \
 - [x] Research Skill (converted from existing notes/documents via `/researchskills-convert`)
 
 ## Skills Added
-<list each skill: type, subtype, domain/subdomain, name>
+<!-- Fill this in: one line per skill, e.g. "- procedural / constraint-failure — statistics/methodology — AUC Computation With Masked Data" -->
 
 ## Checklist
 - [x] Files placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
@@ -240,9 +240,13 @@ EOF
 
 ### 5.7 — Clean up
 
+Only clean up after the PR was successfully created:
+
 ```bash
 rm -rf "$WORK_DIR"
 ```
+
+If any step in Stage 5 fails (fork, clone, push, or PR creation), show the error to the user and suggest manual steps to recover. Do not silently swallow errors.
 
 ---
 

--- a/researchskills-extract/scripts/postinstall.js
+++ b/researchskills-extract/scripts/postinstall.js
@@ -6,7 +6,9 @@ const path = require("path");
 const os = require("os");
 
 const SOURCE_CC_COMMAND = path.join(__dirname, "..", "commands", "researchskills-extract.md");
+const SOURCE_CC_CONVERT = path.join(__dirname, "..", "commands", "researchskills-convert.md");
 const SOURCE_CODEX_SKILL = path.join(__dirname, "..", "commands", "SKILL.md");
+const SOURCE_CODEX_CONVERT = path.join(__dirname, "..", "commands", "CONVERT-SKILL.md");
 
 // Helper scripts that must be available at runtime
 const HELPER_SCRIPTS = [
@@ -32,7 +34,10 @@ try {
   fs.mkdirSync(CC_COMMANDS_DIR, { recursive: true });
   fs.mkdirSync(CC_UTILS_DIR, { recursive: true });
   fs.copyFileSync(SOURCE_CC_COMMAND, CC_COMMAND_TARGET);
+  const CC_CONVERT_TARGET = path.join(CC_COMMANDS_DIR, "researchskills-convert.md");
+  fs.copyFileSync(SOURCE_CC_CONVERT, CC_CONVERT_TARGET);
   console.log("✓ Claude Code: /researchskills-extract installed to ~/.claude/commands/");
+  console.log("✓ Claude Code: /researchskills-convert installed to ~/.claude/commands/");
 
   for (const script of HELPER_SCRIPTS) {
     const src = path.join(__dirname, script);
@@ -58,6 +63,12 @@ try {
   fs.mkdirSync(CODEX_SCRIPTS_DIR, { recursive: true });
   fs.copyFileSync(SOURCE_CODEX_SKILL, CODEX_SKILL_TARGET);
   console.log("✓ Codex:   /researchskills-extract installed to ~/.codex/skills/researchskills-extract/");
+
+  // --- Codex: researchskills-convert ---
+  const CODEX_CONVERT_DIR = path.join(os.homedir(), ".codex", "skills", "researchskills-convert");
+  fs.mkdirSync(CODEX_CONVERT_DIR, { recursive: true });
+  fs.copyFileSync(SOURCE_CODEX_CONVERT, path.join(CODEX_CONVERT_DIR, "SKILL.md"));
+  console.log("✓ Codex:   /researchskills-convert installed to ~/.codex/skills/researchskills-convert/");
 
   for (const script of HELPER_SCRIPTS) {
     const src = path.join(__dirname, script);
@@ -188,4 +199,6 @@ try {
   console.error("⚠ Cache: could not prepare —", err.message);
 }
 
-console.log("\n  Usage: /researchskills-extract (Claude Code) or $researchskills-extract (Codex)");
+console.log("\n  Usage:");
+console.log("    /researchskills-extract  (Claude Code) or $researchskills-extract  (Codex) — extract from history");
+console.log("    /researchskills-convert  (Claude Code) or $researchskills-convert  (Codex) — convert existing skills");

--- a/researchskills-extract/scripts/postuninstall.js
+++ b/researchskills-extract/scripts/postuninstall.js
@@ -21,12 +21,17 @@ const HELPER_SCRIPTS = [
 
 // --- Claude Code ---
 const CC_COMMAND_TARGET = path.join(os.homedir(), ".claude", "commands", "researchskills-extract.md");
+const CC_CONVERT_TARGET = path.join(os.homedir(), ".claude", "commands", "researchskills-convert.md");
 const CC_UTILS_DIR = path.join(os.homedir(), ".claude", "utils");
 
 try {
   if (fs.existsSync(CC_COMMAND_TARGET)) {
     fs.unlinkSync(CC_COMMAND_TARGET);
     console.log("✓ Claude Code: /researchskills-extract removed");
+  }
+  if (fs.existsSync(CC_CONVERT_TARGET)) {
+    fs.unlinkSync(CC_CONVERT_TARGET);
+    console.log("✓ Claude Code: /researchskills-convert removed");
   }
   for (const script of HELPER_SCRIPTS) {
     const p = path.join(CC_UTILS_DIR, script);
@@ -59,6 +64,17 @@ try {
     if (skillRemaining.length === 0) fs.rmdirSync(CODEX_SKILL_DIR);
   } catch (_) { /* best effort */ }
   console.log("✓ Codex: helper scripts removed");
+} catch (err) {
+  // ignore
+}
+
+// --- Codex: researchskills-convert ---
+const CODEX_CONVERT_DIR = path.join(os.homedir(), ".codex", "skills", "researchskills-convert");
+try {
+  if (fs.existsSync(CODEX_CONVERT_DIR)) {
+    fs.rmSync(CODEX_CONVERT_DIR, { recursive: true, force: true });
+    console.log("✓ Codex: /researchskills-convert removed");
+  }
 } catch (err) {
   // ignore
 }


### PR DESCRIPTION
## Summary

- Adds the `/researchskills-convert` skill that the `/convert` page on researchskills.ai and the docs already reference but that didn't exist yet
- The skill guides the LLM to: ask for input, convert research skills into the correct format (procedural/semantic/episodic), fork the repo, create the correct directory structure (`skills/<domain>/<subdomain>/<contributor>/<memory_type>/<subtype>--<name>.md`), and open a PR
- Both Claude Code (`.md`) and Codex (`SKILL.md`) versions included
- Updated `postinstall.js` / `postuninstall.js` to install and clean up both commands

Closes ScienceIntelligence/researchskills-server#157

## Test plan

- [x] Existing `test-postinstall.js` passes (9/9)
- [ ] Run `npm install -g` from this branch and verify `/researchskills-convert` appears in Claude Code
- [ ] Invoke `/researchskills-convert` end-to-end with sample skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)