### PR TITLE
[convert] Add 7 research skills by a-green-hand-jack

### DIFF
--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--evidence-grounding-in-experiment-reports.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--evidence-grounding-in-experiment-reports.md
@@ -1,0 +1,46 @@
+---
+name: "Evidence Grounding In Experiment Reports"
+memory_type: procedural
+subtype: constraint-failure
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Evidence Grounding In Experiment Reports
+
+## When
+
+Use this when writing ML experiment reports, mentor updates, paper-result sections, or lab notes from experiment artifacts such as configs, logs, tables, figures, metrics, and informal notes.
+
+Exclude cases where the output is purely a status note with no scientific claim, no comparison, and no decision to support.
+
+## Decision
+
+Preferred: ground every claim in primary evidence before interpreting the result. Record the experiment question, setup, dataset split, method variant, baseline, metrics, random seeds when available, code version, and exact result values before drawing conclusions.
+
+Rejected: write a polished narrative directly from memory, using phrases such as "the method improves" or "the trend suggests" before identifying the baseline and the measured values.
+
+Reasoning: ML experiment reports often fail because they mix observation and interpretation. A reader cannot audit whether a conclusion follows from the evidence if the setup, comparison target, and metric aggregation are missing.
+
+## Local Verifiers
+
+- Check for a concrete experiment question and baseline or control.
+- Check whether each headline claim has a metric, figure, table, log, config, run ID, or user-provided note as evidence.
+- Check that absolute values and meaningful deltas are both reported when possible.
+- Check that observed results appear before interpretation.
+- Check that missing seeds, splits, runtime, hardware, or code version are marked as missing rather than invented.
+
+## Failure Handling
+
+If primary evidence is incomplete, write the report with explicit missing-evidence notes and ask only for the smallest clarification needed to make the main conclusion auditable.
+
+If figures or tables are present but ambiguous, describe axes, units, scale, aggregation, and error bars before interpreting the visual pattern.
+
+If the result is negative or inconclusive, preserve the uncertainty and convert the conclusion into a decision rule for the next experiment instead of overstating success.
+
+## Anti-exemplars
+
+Do not use this as a generic writing template for documentation with no experimental claim.
+
+Do not force standard background explanations into the report when the research decision only depends on the setup, comparison, and measured outcome.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--research-code-release-blocker-audit.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--research-code-release-blocker-audit.md
@@ -1,0 +1,46 @@
+---
+name: "Research Code Release Blocker Audit"
+memory_type: procedural
+subtype: constraint-failure
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Research Code Release Blocker Audit
+
+## When
+
+Use this when preparing an ML or scientific code repository for public release alongside a paper, arXiv preprint, conference submission, GitHub release, or reproducibility package.
+
+Exclude purely private internal handoffs where no public artifact will be created.
+
+## Decision
+
+Preferred: perform a blocker audit before generating release polish. First check for secrets, credentials, private paths, large binaries, missing license, missing citation metadata, skeletal README, committed outputs, and reproducibility gaps.
+
+Rejected: start by writing release notes or improving the README while security, legal, or artifact-size risks remain unknown.
+
+Reasoning: public research releases fail most severely when they leak private credentials or publish unreproducible artifacts. Documentation polish is secondary until blockers are classified.
+
+## Local Verifiers
+
+- Search code and config files for password, token, API key, credential, private key, and secret patterns.
+- Find sensitive files such as `.env`, key files, private certificates, secrets files, and credential JSON files.
+- Find large files over the repository's intended threshold, excluding deliberately externalized outputs.
+- Check whether README, LICENSE, CITATION, dependency files, and ignore rules exist.
+- Inspect git status and recent commits before tagging or publishing.
+
+## Failure Handling
+
+If secrets or credentials are found, stop release work and ask the user to remove and rotate them before continuing.
+
+If large artifacts are present, move them to an external release channel such as a model hub, dataset repository, or release asset instead of committing them as ordinary source files.
+
+If README or citation metadata is missing, generate them with explicit TODO markers for claims that require author-provided numbers, URLs, or model-weight locations.
+
+## Anti-exemplars
+
+Do not create a public tag or GitHub release while blockers remain unresolved.
+
+Do not overwrite a substantial existing README without explicit user approval; identify missing sections instead.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--submission-readiness-checks-for-anonymous-papers.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/constraint-failure--submission-readiness-checks-for-anonymous-papers.md
@@ -1,0 +1,48 @@
+---
+name: "Submission Readiness Checks For Anonymous Papers"
+memory_type: procedural
+subtype: constraint-failure
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Submission Readiness Checks For Anonymous Papers
+
+## When
+
+Use this before submitting a LaTeX ML, NLP, CV, or computer-science paper to a conference, especially for anonymous review, camera-ready, or arXiv conversion.
+
+Exclude ordinary draft editing where the goal is prose quality rather than submission compliance.
+
+## Decision
+
+Preferred: run a systematic readiness check that separates blocking failures from warnings. Verify submission mode, anonymity, TODO artifacts, bibliography wiring, mandatory venue sections, abstract length, figure and table references, and optional compilation/page-count status.
+
+Rejected: only compile the PDF and assume successful compilation means the paper is submission-ready.
+
+Reasoning: many submission failures are semantic or policy failures rather than LaTeX compilation failures. Anonymous review can be broken by acknowledgements, personal URLs, funding disclosures, author macros, or wrong style options even when the PDF builds.
+
+## Local Verifiers
+
+- `main.tex` and venue preamble exist and use the intended anonymous, preprint, or camera-ready mode.
+- TODO, FIXME, colored revision macros, and author comment macros are absent or intentionally retained.
+- Acknowledgements, funding disclosures, email addresses, and personal URLs are removed or hidden for anonymous submission.
+- Required venue sections such as limitations, broader impact, ethics, or checklist are present when applicable.
+- Bibliography files are non-empty and connected to the main document.
+- Figure and table labels are referenced in text.
+- Compilation output has no unresolved references, missing citations, or page-limit surprises when compilation is requested.
+
+## Failure Handling
+
+If the submission mode is wrong, edit only the central venue preamble or equivalent style switch rather than changing scattered style commands.
+
+If anonymity blockers are found, show file and line references and ask before removing content that may be needed for camera-ready or arXiv versions.
+
+If mandatory sections are missing, add explicit placeholders only with user approval because placeholder text may still be a submission risk.
+
+## Anti-exemplars
+
+Do not treat a clean LaTeX build as sufficient evidence of readiness.
+
+Do not automatically remove acknowledgements or author information when the target mode is camera-ready or arXiv.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/no-change--reproducible-job-scripts-for-ml-experiments.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/no-change--reproducible-job-scripts-for-ml-experiments.md
@@ -1,0 +1,46 @@
+---
+name: "Reproducible Job Scripts For ML Experiments"
+memory_type: procedural
+subtype: no-change
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Reproducible Job Scripts For ML Experiments
+
+## When
+
+Use this before launching ML training, evaluation, ablations, or sweeps on local machines, SLURM clusters, or Kubernetes-style GPU platforms.
+
+Exclude one-off exploratory shell commands where no result will be compared, reported, or reused.
+
+## Decision
+
+Preferred: materialize a committed job script before submission. The script should capture the project root, git commit, environment activation, scheduler resources, log directory, output directory, and exact run command.
+
+Rejected: submit long interactive shell commands directly to the scheduler and rely on shell history or queue metadata to reconstruct the experiment later.
+
+Reasoning: scheduler records are volatile and often omit the scientific context. A saved job script creates an audit trail for the run and lets later reports distinguish code state, resource allocation, command line, and output location.
+
+## Local Verifiers
+
+- The job script records a short git commit hash or explicitly says that the run was outside git.
+- Logs and outputs are written under predictable experiment-specific directories.
+- The resource request is explicit: GPU count, CPU count, memory, walltime, partition or queue, and container image when applicable.
+- Environment activation is visible in the script.
+- The submit command can be copied and rerun without relying on hidden interactive state.
+
+## Failure Handling
+
+If the target environment is unknown, first classify the scheduler as local, SLURM-compatible, Kubernetes/RunAI-compatible, or other; then generate the closest minimal wrapper and mark fields that need confirmation.
+
+If the project has uncommitted changes, record that fact in the run notes or ask whether to commit before submission.
+
+If environment activation is unclear, prefer making the script explicit with a placeholder over silently inheriting the current shell state.
+
+## Anti-exemplars
+
+Do not use this to replace a full experiment tracker; the script is the launch record, not the complete result database.
+
+Do not submit a job script before the user has reviewed resource settings when the run consumes scarce shared GPU resources.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/tie--evidence-backed-work-timeline-blocks.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/tie--evidence-backed-work-timeline-blocks.md
@@ -1,0 +1,46 @@
+---
+name: "Evidence Backed Work Timeline Blocks"
+memory_type: procedural
+subtype: tie
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Evidence Backed Work Timeline Blocks
+
+## When
+
+Use this when building a retrospective research timeline, mentor update, project progress report, or next-phase plan from git history, project docs, experiment logs, meeting notes, or user-provided context.
+
+Exclude cases where the user explicitly wants a raw commit log or a complete chronological transcript.
+
+## Decision
+
+Preferred: convert raw evidence into a small number of meaningful work blocks. Each block should include project, title, date range, work type, evidence basis, and concrete outcome.
+
+Rejected: map every commit to a separate timeline item or infer a detailed day-by-day plan from sparse evidence.
+
+Reasoning: research progress is usually organized by questions, experiments, debugging episodes, writing phases, and decisions, not by individual commits. Commit history is a useful signal but often misses reading, analysis, failed runs, discussion, and writing.
+
+## Local Verifiers
+
+- Each timeline block cites an evidence basis such as commits, docs, experiment logs, notes, or user context.
+- Observed facts are separated from inferred date ranges.
+- Multi-project reports keep project boundaries explicit.
+- Mentor-facing reports emphasize outcomes and decisions, not raw activity volume.
+- Planned work is separated from completed work and includes dependencies or uncertainty when relevant.
+
+## Failure Handling
+
+If git history is sparse, supplement it with docs, notes, experiment logs, or user-provided context instead of pretending commits fully describe the work.
+
+If evidence conflicts, mark the uncertainty in the report and avoid over-precise dates.
+
+If the user asks for forward planning, use milestone-sized blocks with dependencies rather than fabricated daily precision.
+
+## Anti-exemplars
+
+Do not use this to produce compliance-grade timesheets unless exact timestamps and activity records are available.
+
+Do not collapse multiple projects into one timeline without preserving which evidence belongs to which project.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/procedural/tie--reverse-chronological-experiment-result-logging.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/procedural/tie--reverse-chronological-experiment-result-logging.md
@@ -1,0 +1,46 @@
+---
+name: "Reverse Chronological Experiment Result Logging"
+memory_type: procedural
+subtype: tie
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Reverse Chronological Experiment Result Logging
+
+## When
+
+Use this when recording new ML experiment results into a paper-side experiment log, research diary, or shared project notes that are meant to support later writing and comparison.
+
+Exclude cases where results are already stored in a structured experiment tracker and the task is only to query that tracker.
+
+## Decision
+
+Preferred: append each experiment batch as a compact structured entry at the top of the log, with date, short title, setup, result, observation, and next experiment.
+
+Rejected: keep results only in terminal logs, chat history, checkpoint names, or chronologically appended notes that require scrolling through stale entries first.
+
+Reasoning: research writing usually needs the latest evidence first. Reverse chronological logging makes recent decisions recoverable while preserving older context, and the fixed fields force the researcher to separate configuration, measured outcome, interpretation, and follow-up.
+
+## Local Verifiers
+
+- The newest entry appears near the top of the experiment log.
+- The entry includes setup, measured results, observation, and next step as separate fields.
+- The setup includes the method variant, dataset or split, and important config differences from the baseline when known.
+- The result field contains concrete metrics rather than only prose.
+- The next step is a testable follow-up, not a vague intention.
+
+## Failure Handling
+
+If metrics are spread across logs or output folders, inspect the most recent experiment artifacts and pre-fill the entry, then require human confirmation before writing it into the paper log.
+
+If the paper repository cannot be located automatically, ask for the paper path rather than creating a detached log in the code repository.
+
+If the result interpretation is uncertain, write the observation as a hypothesis and make the next step a discriminating experiment.
+
+## Anti-exemplars
+
+Do not use this for final paper result tables; those need curation, statistical checking, and consistent formatting.
+
+Do not overwrite or reorder older entries unless the user explicitly asks for log cleanup.

--- a/skills/computer-science/machine-learning/a-green-hand-jack/semantic/correction--venue-preamble-isolation-for-paper-templates.md
+++ b/skills/computer-science/machine-learning/a-green-hand-jack/semantic/correction--venue-preamble-isolation-for-paper-templates.md
@@ -1,0 +1,28 @@
+---
+name: "Venue Preamble Isolation For Paper Templates"
+memory_type: semantic
+subtype: correction
+domain: computer-science
+subdomain: machine-learning
+contributor: a-green-hand-jack
+---
+
+# Venue Preamble Isolation For Paper Templates
+
+## Fact
+
+For reusable LaTeX paper templates across ML and computer-science venues, venue-specific style loading should be isolated in a generated `venue_preamble.tex` or equivalent central file, while `main.tex` should input that file and remain stable across anonymous, preprint, and camera-ready modes.
+
+## Evidence
+
+Conference style files vary by venue and year: NeurIPS, ICML, ICLR, CVPR, ICCV, ACL-family, ECCV, and ACM use different package names, bibliography styles, author macros, and review/final options. Centralizing the venue style switch prevents repeated edits to the main paper body and makes mode changes auditable.
+
+This pattern also localizes fixes for venue-specific conflicts such as duplicate `cleveref` loading, legacy `algorithmic` conflicts with `algpseudocode`, and class-specific citation behavior.
+
+## LLM Default Belief
+
+LLMs often suggest placing `\usepackage{<venue>}` directly in `main.tex` and editing that line whenever the target venue or submission mode changes. That works for one paper but is brittle for reusable templates because anonymous, arXiv, and camera-ready mode changes become scattered and easy to miss.
+
+## Expiry Signal
+
+Revisit this if major venues standardize style loading through a common package manager or if the target project intentionally supports only one venue and one submission mode.


### PR DESCRIPTION
## Submission Type
- [x] Research Skill (converted from existing notes/documents via `/researchskills-convert`)

## Skills Added
- procedural / constraint-failure — computer-science/machine-learning — Evidence Grounding In Experiment Reports
- procedural / tie — computer-science/machine-learning — Reverse Chronological Experiment Result Logging
- procedural / no-change — computer-science/machine-learning — Reproducible Job Scripts For ML Experiments
- procedural / constraint-failure — computer-science/machine-learning — Research Code Release Blocker Audit
- procedural / constraint-failure — computer-science/machine-learning — Submission Readiness Checks For Anonymous Papers
- semantic / correction — computer-science/machine-learning — Venue Preamble Isolation For Paper Templates
- procedural / tie — computer-science/machine-learning — Evidence Backed Work Timeline Blocks

## Checklist
- [x] Files placed in `skills/<domain>/<subdomain>/<contributor>/<memory_type>/`
- [x] Filenames follow pattern `<subtype>--<skill-name>.md`
- [x] All required frontmatter fields filled
- [x] All required body sections present
- [x] Content is de-identified
- [x] All content in English
