### PR TITLE
fix(extract): broaden research classification for computational science

### DIFF
--- a/researchskills-extract/scripts/classify-projects.js
+++ b/researchskills-extract/scripts/classify-projects.js
@@ -113,7 +113,7 @@ ${taxonomyStr}
 ## Task
 ${isTest
     ? 'TEST MODE: Accept both research AND engineering projects. Map engineering to computer-science/software-engineering or the closest match.'
-    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, academic writing, OR computational science (writing simulations, solvers, numerical methods, scientific data analysis pipelines, scientific computing code whose purpose is to answer a research question). Software engineering (web dev, deployment, debugging non-scientific tools, UI work, auth, package management) is NOT research regardless of difficulty. Computational science — where the code IS the science — counts as research.'}
+    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, academic writing, OR computational science where the code is written to answer or validate a research question (simulations, solvers, numerical methods, scientific data analysis pipelines). Reusable numerics libraries or benchmark harnesses with no specific scientific inquiry are engineering, not research. Software engineering (web dev, deployment, debugging non-scientific tools, UI work, auth, package management) is NOT research regardless of difficulty.'}
 
 Respond with EXACTLY this JSON (no markdown fences, no other text):
 {"type":"research","domain":"...","subdomain":"...","project_name":"...","reason":"one sentence why","skip_patterns":["pattern1"]}

--- a/researchskills-extract/scripts/classify-projects.js
+++ b/researchskills-extract/scripts/classify-projects.js
@@ -113,7 +113,7 @@ ${taxonomyStr}
 ## Task
 ${isTest
     ? 'TEST MODE: Accept both research AND engineering projects. Map engineering to computer-science/software-engineering or the closest match.'
-    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, or academic writing. Software engineering (web dev, deployment, debugging, UI work) is NOT research regardless of difficulty.'}
+    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, academic writing, OR computational science (writing simulations, solvers, numerical methods, data analysis pipelines, scientific computing code whose purpose is to answer a research question). Software engineering (web dev, deployment, debugging non-scientific tools, UI work, auth, package management) is NOT research regardless of difficulty. Computational science — where the code IS the science — counts as research.'}
 
 Respond with EXACTLY this JSON (no markdown fences, no other text):
 {"type":"research","domain":"...","subdomain":"...","project_name":"...","reason":"one sentence why","skip_patterns":["pattern1"]}

--- a/researchskills-extract/scripts/classify-projects.js
+++ b/researchskills-extract/scripts/classify-projects.js
@@ -113,7 +113,7 @@ ${taxonomyStr}
 ## Task
 ${isTest
     ? 'TEST MODE: Accept both research AND engineering projects. Map engineering to computer-science/software-engineering or the closest match.'
-    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, academic writing, OR computational science (writing simulations, solvers, numerical methods, data analysis pipelines, scientific computing code whose purpose is to answer a research question). Software engineering (web dev, deployment, debugging non-scientific tools, UI work, auth, package management) is NOT research regardless of difficulty. Computational science — where the code IS the science — counts as research.'}
+    : 'PRODUCTION MODE: Only classify as "research" if the sessions involve genuine scientific inquiry, research methodology, hypothesis testing, academic writing, OR computational science (writing simulations, solvers, numerical methods, scientific data analysis pipelines, scientific computing code whose purpose is to answer a research question). Software engineering (web dev, deployment, debugging non-scientific tools, UI work, auth, package management) is NOT research regardless of difficulty. Computational science — where the code IS the science — counts as research.'}
 
 Respond with EXACTLY this JSON (no markdown fences, no other text):
 {"type":"research","domain":"...","subdomain":"...","project_name":"...","reason":"one sentence why","skip_patterns":["pattern1"]}

--- a/researchskills-extract/scripts/clean-skills.js
+++ b/researchskills-extract/scripts/clean-skills.js
@@ -93,6 +93,7 @@ KEEP skills about:
 - Domain facts that AI doesn't know (frontier knowledge, unpublished info, corrections to LLM misconceptions)
 - Concrete research turning points (hypothesis overturned, methodology abandoned, unexpected findings)
 - Knowledge representation methodology (schema design for capturing research decision trees) — ONLY when discussing "how to represent scientific knowledge", NOT "how to code the implementation"
+- Computational science methods (numerical algorithms, solver configurations, simulation setup, scientific data preprocessing) — where the code implements or validates a scientific method, not generic software engineering
 
 ### 2. Check for residual PII
 

--- a/researchskills-extract/scripts/clean-skills.js
+++ b/researchskills-extract/scripts/clean-skills.js
@@ -93,7 +93,7 @@ KEEP skills about:
 - Domain facts that AI doesn't know (frontier knowledge, unpublished info, corrections to LLM misconceptions)
 - Concrete research turning points (hypothesis overturned, methodology abandoned, unexpected findings)
 - Knowledge representation methodology (schema design for capturing research decision trees) — ONLY when discussing "how to represent scientific knowledge", NOT "how to code the implementation"
-- Computational science methods (numerical algorithms, solver configurations, simulation setup, scientific data preprocessing) — where the code implements or validates a scientific method, not generic software engineering
+- Computational science methods (numerical algorithms, solver configurations, simulation setup, scientific data analysis and preprocessing) — where the code implements or validates a scientific method, not generic software engineering
 
 ### 2. Check for residual PII
 

--- a/researchskills-extract/scripts/extract-skills.js
+++ b/researchskills-extract/scripts/extract-skills.js
@@ -171,13 +171,13 @@ function buildPrompt(segmentFile) {
 
 1. **Non-obvious** — would a domain expert find this surprising?
 2. **Session-specific** — grounded in a concrete event here, not generic advice?
-3. **Research-only** — about scientific methodology, reasoning, or knowledge? Reject all engineering (UI, DevOps, database, build tools, git, auth, package management, visualization) even if the project is research-related.
+3. **Research-only** — about scientific methodology, reasoning, knowledge, OR computational science methods (simulations, solvers, numerical algorithms, scientific data analysis)? Reject pure software engineering (UI, DevOps, database, build tools, git, auth, package management) even if the project is research-related. But DO extract skills about scientific computing where the code implements or validates a scientific method.
 
 ## Boundary examples — same project, different verdicts
 
 A research project contains BOTH research and engineering work. Extract only the research.
 
-❌ REJECT (engineering):
+❌ REJECT (pure engineering):
 - "Supabase onAuthStateChange callback deadlocks on re-entry" → auth/infra debugging
 - "GitHub Rulesets vs Branch Protection Rules show different UI warnings" → platform ops
 - "Static PNG unreadable at 130+ nodes, switch to interactive HTML/JS tree" → UI/visualization choice
@@ -189,7 +189,13 @@ A research project contains BOTH research and engineering work. Extract only the
 - "LLMs fail at research due to task structure mismatch (long horizon + no verifier), not reasoning deficits" → frontier knowledge about AI capabilities
 - "Predefined 20-action vocabulary with escape hatch balances structure vs flexibility for research ontology" → schema design for knowledge representation
 
-When in doubt, ask: "Is this about HOW to do science, or HOW to build software?" Only the former qualifies.
+✅ EXTRACT (computational science — code IS the science):
+- "FFT-based spectral method converges 10x faster than finite-difference for periodic MHD boundary conditions" → numerical method selection for domain physics
+- "Helmholtz decomposition requires divergence-free initial field; naive random initialization violates ∇·B=0" → constraint on simulation setup
+- "Tracking magnetic field lines near coil edges fails with RK4 step > 0.01 due to high curvature" → numerical stability boundary for specific geometry
+- "Alfvénic wave flux from PSP data requires detrending at spacecraft spin period before spectral analysis" → data preprocessing for space physics
+
+When in doubt, ask: "Is this about HOW to do science (including computational science), or HOW to build software unrelated to the research question?" Only the former qualifies.
 
 ## Skill types
 


### PR DESCRIPTION
## Summary

- Broadens the extraction pipeline's research classification to recognize **computational science** (simulations, solvers, numerical methods, scientific data analysis) as research, not engineering
- Fixes #81: sessions involving MHD simulations, Helmholtz solvers, FFT acceleration, and space physics data analysis were being rejected as "engineering" — resulting in 0 skills extracted from 146 sessions
- Changes touch all three AI prompts in the pipeline (classify → extract → clean) for consistency

### What changed

| File | Change |
|------|--------|
| `classify-projects.js` | PRODUCTION MODE prompt now accepts computational science tied to a research question |
| `extract-skills.js` | Quality gate rule 3 includes computational science methods; added 4 boundary examples (MHD, Helmholtz, field line tracking, PSP data) |
| `clean-skills.js` | KEEP list includes computational science methods so Opus review doesn't reject them |

### Key design decisions

- Computational science is only classified as research when **the code answers or validates a research question** — reusable numerics libraries/benchmark harnesses remain "engineering"
- The extraction prompt distinguishes "pure engineering" from "computational science where the code IS the science"
- All three pipeline stages (classify, extract, clean) use consistent vocabulary

## Test plan

- [ ] Run `/researchskills-extract` on a user with computational physics sessions (MHD, Helmholtz solvers) and verify sessions are classified as "research"
- [ ] Verify that pure software engineering projects (web dev, CI/CD) are still correctly classified as "engineering"
- [ ] Verify extracted skills from computational science sessions pass the clean stage without being rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)