### PR TITLE
fix(docs): add Node.js install prerequisite (#83)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,8 @@ Each skill encodes the knowledge, tools, reasoning protocols, and common pitfall
 
 ### Method A: Auto-Extract with `/researchskills-extract` (Recommended)
 
+> **Prerequisite:** [Install Node.js](https://nodejs.org/) (includes npm). LTS version recommended.
+
 ```bash
 npm install -g @scienceintelligence/researchskills-extract
 ```

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -56,6 +56,8 @@
 
 ### 方式 A：用 `/researchskills-extract` 自动提取（推荐）
 
+> **前置条件：** [安装 Node.js](https://nodejs.org/)（自带 npm）。推荐 LTS 版本。
+
 ```bash
 npm install -g @scienceintelligence/researchskills-extract
 ```


### PR DESCRIPTION
## Summary
- Adds a one-line prerequisite note before the first `npm install` command in both `readme.md` and `readme_zh.md`
- Users who don't have npm installed now see a link to install Node.js (which includes npm)

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)