### PR TITLE
Sync management into the public knowledge tree

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,7 +181,7 @@
   <h1><span class="emoji">🌍</span> ResearchSkills</h1>
   <p>Interactive knowledge tree — aligned with the
     <a href="https://arxiv.org/category_taxonomy" target="_blank">arXiv category taxonomy</a>.
-    Click a domain to explore its subcategories.
+    Includes an additional management domain. Click a domain to explore its subcategories.
   </p>
 </header>
 
@@ -380,6 +380,36 @@ var DATA = [
       { name: "Risk Management", code: "q-fin.RM" },
       { name: "Statistical Finance", code: "q-fin.ST" },
       { name: "Trading and Market Microstructure", code: "q-fin.TR" },
+    ]},
+  ]},
+  { name: "Social Sciences", icon: "\ud83e\udde9", children: [
+    { name: "Management", icon: "\ud83c\udfe2", code: "", color: "#f472b6", children: [
+      { name: "Careers" },
+      { name: "Communication, Digital Technology, and Organization" },
+      { name: "Conflict Management" },
+      { name: "Critical Management Studies" },
+      { name: "Diversity, Equity, and Inclusion" },
+      { name: "Entrepreneurship" },
+      { name: "Health Care Management" },
+      { name: "Human Resources" },
+      { name: "International Management" },
+      { name: "Management Consulting" },
+      { name: "Management Education and Development" },
+      { name: "Management History" },
+      { name: "Management Spirituality and Religion" },
+      { name: "Managerial and Organizational Cognition" },
+      { name: "Operations and Supply Chain Management" },
+      { name: "Organization and Management Theory" },
+      { name: "Organization Development and Change" },
+      { name: "Organizational Behavior" },
+      { name: "Organizational Neuroscience and Biology" },
+      { name: "Organizations and the Natural Environment" },
+      { name: "Public and Nonprofit" },
+      { name: "Research Methods" },
+      { name: "Social Issues in Management" },
+      { name: "Strategic Management" },
+      { name: "Strategizing Activities and Practices" },
+      { name: "Technology and Innovation Management" },
     ]},
   ]},
 ];
@@ -601,7 +631,7 @@ function countReviewers(arr) {
   return n;
 }
 
-var totalDomains = 8;
+var totalDomains = 9;
 var totalSubs = DATA.reduce(function(s,g){ return s + countLeaves(g); }, 0);
 var totalReviewers = countReviewers(DATA);
 

--- a/readme.md
+++ b/readme.md
@@ -167,8 +167,8 @@ Classified using Case-Based Reasoning terminology:
 
 ```
 skills/
-└── {domain}/                    # 8 arXiv-aligned domains
-    └── {subdomain}/             # 155 subcategories
+└── {domain}/                    # 8 arXiv-aligned domains + management
+    └── {subdomain}/             # 181 subcategories
         └── {contributor}/       # Your name
             ├── procedural/      # tie--, no-change--, constraint-failure--, operator-fail--
             ├── semantic/        # frontier--, non-public--, correction--
@@ -197,7 +197,7 @@ Reviewers are domain experts who guard the scientific quality of skills in their
 
 <div align="center">
 
-Aligned with the [arXiv category taxonomy](https://arxiv.org/category_taxonomy). 8 domains, 155 subcategories.
+Aligned with the [arXiv category taxonomy](https://arxiv.org/category_taxonomy), plus one management domain. 9 domains, 181 subcategories.
 
 | Domain                                      | arXiv                                              | Subcategories | Reviewer(s)        |
 | --------------------------------------------- | ---------------------------------------------------- | --------------- | -------------------- |
@@ -208,9 +208,10 @@ Aligned with the [arXiv category taxonomy](https://arxiv.org/category_taxonomy).
 | 📊 Statistics                               | stat                                               | 6             | *Seeking reviewer* |
 | ⚡ Electrical Engineering & Systems Science | eess                                               | 4             | *Seeking reviewer* |
 | 📈 Economics                                | econ                                               | 3             | *Seeking reviewer* |
+| 🏢 Management                               | N/A                                                | 26            | *Seeking reviewer* |
 | 💹 Quantitative Finance                     | q-fin                                              | 9             | *Seeking reviewer* |
 
-[View all 155 subcategories in the interactive knowledge tree →](https://scienceintelligence.github.io/ResearchSkills/)
+[View all 181 subcategories in the interactive knowledge tree →](https://scienceintelligence.github.io/ResearchSkills/)
 
 </div>
 

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -236,8 +236,8 @@ ResearchSkills 的 Skill 设计基于认知架构理论 — [Soar](https://en.wi
 
 ```
 skills/
-└── {domain}/                    # 8 个 arXiv 对齐的顶层领域
-    └── {subdomain}/             # 155 个子领域
+└── {domain}/                    # 8 个 arXiv 对齐的顶层领域 + management
+    └── {subdomain}/             # 181 个子领域
         └── {contributor}/       # 你的名字
             ├── procedural/      # tie--, no-change--, constraint-failure--, operator-fail--
             ├── semantic/        # frontier--, non-public--, correction--
@@ -266,7 +266,7 @@ skills/
 
 <div align="center">
 
-对齐 [arXiv 分类体系](https://arxiv.org/category_taxonomy)。8 个顶层领域，155 个子领域。
+对齐 [arXiv 分类体系](https://arxiv.org/category_taxonomy)，并补充了 management 领域。9 个顶层领域，181 个子领域。
 
 | 领域                                                           | arXiv                                              | 子领域数 | 审稿人   |
 | ---------------------------------------------------------------- | ---------------------------------------------------- | ---------- | ---------- |
@@ -277,9 +277,10 @@ skills/
 | 📊 Statistics 统计学                                           | stat                                               | 6        | *招募中* |
 | ⚡ Electrical Engineering & Systems Science 电气工程与系统科学 | eess                                               | 4        | *招募中* |
 | 📈 Economics 经济学                                            | econ                                               | 3        | *招募中* |
+| 🏢 Management 管理学                                           | N/A                                                | 26       | *招募中* |
 | 💹 Quantitative Finance 定量金融                               | q-fin                                              | 9        | *招募中* |
 
-[查看全部 155 个子领域（交互式知识树）→](https://scienceintelligence.github.io/ResearchSkills/)
+[查看全部 181 个子领域（交互式知识树）→](https://scienceintelligence.github.io/ResearchSkills/)
 
 </div>
 


### PR DESCRIPTION
This PR syncs the newly added `management` taxonomy into the public-facing knowledge tree and README docs.

Scope of this PR:
- add `Management` and its 26 subdomains to `docs/index.html`
- update the public domain/subcategory counts from 8/155 to 9/181
- update both `readme.md` and `readme_zh.md` to match the current taxonomy

Context:
- the `skills/management/...` scaffold was already merged in PR #101
- the website knowledge tree and README summaries were still using the older hardcoded taxonomy
